### PR TITLE
Properly handle NaN and infinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## ChangeLog
 
+* The SDK will now check metrics for infinity and NaN.  Metrics with invalid
+values will be rejected, and will result in an error logged.
+
 ## 0.1.0
 
 First release!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * The SDK will now check metrics for infinity and NaN.  Metrics with invalid
 values will be rejected, and will result in an error logged.
 
+* Added `Config.Product` and `Config.ProductVersion` fields which are
+used to the `User-Agent` header if set.
+
 ## 0.1.0
 
 First release!

--- a/internal/attributes_test.go
+++ b/internal/attributes_test.go
@@ -5,6 +5,7 @@ package internal
 
 import (
 	"bytes"
+	"math"
 	"strconv"
 	"testing"
 )
@@ -32,6 +33,9 @@ func TestAttributesWriteJSON(t *testing.T) {
 		{"float32", float32(1), `{"float32":1}`},
 		{"float64", float64(1), `{"float64":1}`},
 		{"default", func() {}, `{"default":"func()"}`},
+		{"NaN", math.NaN(), `{"NaN":"NaN"}`},
+		{"positive-infinity", math.Inf(1), `{"positive-infinity":"infinity"}`},
+		{"negative-infinity", math.Inf(-1), `{"negative-infinity":"infinity"}`},
 	}
 
 	for _, test := range tests {

--- a/internal/jsonx/encode.go
+++ b/internal/jsonx/encode.go
@@ -8,9 +8,7 @@ package jsonx
 
 import (
 	"bytes"
-	"encoding/json"
 	"math"
-	"reflect"
 	"strconv"
 	"unicode/utf8"
 )
@@ -104,33 +102,30 @@ func AppendStringArray(buf *bytes.Buffer, a ...string) {
 }
 
 // AppendFloat appends a numeric literal representing the value to buf.
-func AppendFloat(buf *bytes.Buffer, x float64) error {
+func AppendFloat(buf *bytes.Buffer, x float64) {
 	var scratch [64]byte
 
-	if math.IsInf(x, 0) || math.IsNaN(x) {
-		return &json.UnsupportedValueError{
-			Value: reflect.ValueOf(x),
-			Str:   strconv.FormatFloat(x, 'g', -1, 64),
-		}
+	if math.IsInf(x, 0) {
+		AppendString(buf, "infinity")
+		return
 	}
-
+	if math.IsNaN(x) {
+		AppendString(buf, "NaN")
+		return
+	}
 	buf.Write(strconv.AppendFloat(scratch[:0], x, 'g', -1, 64))
-	return nil
 }
 
 // AppendFloatArray appends an array of numeric literals to buf.
-func AppendFloatArray(buf *bytes.Buffer, a ...float64) error {
+func AppendFloatArray(buf *bytes.Buffer, a ...float64) {
 	buf.WriteByte('[')
 	for i, x := range a {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		if err := AppendFloat(buf, x); err != nil {
-			return err
-		}
+		AppendFloat(buf, x)
 	}
 	buf.WriteByte(']')
-	return nil
 }
 
 // AppendInt appends a numeric literal representing the value to buf.

--- a/internal/jsonx/encode_test.go
+++ b/internal/jsonx/encode_test.go
@@ -12,20 +12,21 @@ import (
 
 func TestAppendFloat(t *testing.T) {
 	buf := &bytes.Buffer{}
-
-	err := AppendFloat(buf, math.NaN())
-	if err == nil {
-		t.Error("AppendFloat(NaN) should return an error")
+	AppendFloat(buf, math.NaN())
+	if want, got := `"NaN"`, buf.String(); want != got {
+		t.Error(got, want)
 	}
 
-	err = AppendFloat(buf, math.Inf(1))
-	if err == nil {
-		t.Error("AppendFloat(+Inf) should return an error")
+	buf.Reset()
+	AppendFloat(buf, math.Inf(1))
+	if want, got := `"infinity"`, buf.String(); want != got {
+		t.Error(got, want)
 	}
 
-	err = AppendFloat(buf, math.Inf(-1))
-	if err == nil {
-		t.Error("AppendFloat(-Inf) should return an error")
+	buf.Reset()
+	AppendFloat(buf, math.Inf(-1))
+	if want, got := `"infinity"`, buf.String(); want != got {
+		t.Error(got, want)
 	}
 }
 

--- a/telemetry/harvester.go
+++ b/telemetry/harvester.go
@@ -136,6 +136,11 @@ func (h *Harvester) RecordMetric(m Metric) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
 
+	if fields := m.validate(); nil != fields {
+		h.config.logError(fields)
+		return
+	}
+
 	h.rawMetrics = append(h.rawMetrics, m)
 }
 


### PR DESCRIPTION
* Attribute float values which are infinity/nan will be JSON encoded as string values.
* Metrics which have invalid values will now be rejected, and will result in a logged error.