### PR TITLE
Re-add request body when retrying.

### DIFF
--- a/telemetry/harvester.go
+++ b/telemetry/harvester.go
@@ -4,6 +4,7 @@
 package telemetry
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -320,6 +321,10 @@ func harvestRequest(req request, cfg *Config) {
 			return
 		}
 		attempts++
+
+		// Reattach request body because the original one has already been read
+		// and closed.
+		req.Request.Body = ioutil.NopCloser(bytes.NewBuffer(req.compressedBody))
 	}
 }
 

--- a/telemetry/request.go
+++ b/telemetry/request.go
@@ -21,6 +21,7 @@ type request struct {
 	Request          *http.Request
 	UncompressedBody json.RawMessage
 
+	compressedBody       []byte
 	compressedBodyLength int
 }
 
@@ -60,6 +61,7 @@ func newRequestsInternal(batch requestsBuilder, apiKey string, url string, userA
 	r := request{
 		Request:              req,
 		UncompressedBody:     uncompressed,
+		compressedBody:       compressed.Bytes(),
 		compressedBodyLength: compressedLen,
 	}
 


### PR DESCRIPTION
According to this [StackOverflow answer](https://stackoverflow.com/a/31338443/1020391) if the exact same request is used multiple times, the content-length header will not match the length of the actual request body. That is because once the request body is used once, the `io.ReadCloser` body has been exhausted. To retry, we must re-attach a fresh version of the body.