### PR TITLE
feat: added ability to configure SDK client to use an external context

### DIFF
--- a/telemetry/config.go
+++ b/telemetry/config.go
@@ -4,6 +4,7 @@
 package telemetry
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"log"
@@ -49,6 +50,8 @@ type Config struct {
 	Product string
 	// ProductVersion is added to the User-Agent header. eg. "0.1.0".
 	ProductVersion string
+	// Context is the Context to use for making requests
+	Context context.Context
 }
 
 // ConfigAPIKey sets the Config's APIKey which is required and refers to your
@@ -64,6 +67,14 @@ func ConfigAPIKey(key string) func(*Config) {
 func ConfigCommonAttributes(attributes map[string]interface{}) func(*Config) {
 	return func(cfg *Config) {
 		cfg.CommonAttributes = attributes
+	}
+}
+
+// ConfigContext add the given context.Context to the Config's
+// Context field
+func ConfigContext(ctx context.Context) func(*Config) {
+	return func(cfg *Config) {
+		cfg.Context = ctx
 	}
 }
 

--- a/telemetry/config_test.go
+++ b/telemetry/config_test.go
@@ -5,6 +5,7 @@ package telemetry
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 )
@@ -53,6 +54,17 @@ func TestConfigBasicErrorLogger(t *testing.T) {
 	h.config.logError(map[string]interface{}{"zip": func() {}})
 	if log := buf.String(); !strings.Contains(log, "json: unsupported type: func()") {
 		t.Error("message not logged correctly", log)
+	}
+}
+
+func TestConfigContext(t *testing.T) {
+	ctx := context.Background()
+	h, err := NewHarvester(ConfigAPIKey("apikey"), ConfigContext(ctx))
+	if nil == h || err != nil {
+		t.Fatal(h, err)
+	}
+	if ctx != h.config.Context {
+		t.Error("config func does not set context correctly")
 	}
 }
 

--- a/telemetry/harvester.go
+++ b/telemetry/harvester.go
@@ -49,6 +49,7 @@ func NewHarvester(options ...func(*Config)) (*Harvester, error) {
 		Client:         &http.Client{},
 		HarvestPeriod:  defaultHarvestPeriod,
 		HarvestTimeout: defaultHarvestTimeout,
+		Context:        context.Background(),
 	}
 	for _, opt := range options {
 		opt(&cfg)
@@ -379,8 +380,13 @@ func harvestRoutine(h *Harvester) {
 	time.Sleep(jitter)
 
 	ticker := time.NewTicker(h.config.HarvestPeriod)
-	for range ticker.C {
-		go h.HarvestNow(context.Background())
+	for {
+		select {
+		case <-ticker.C:
+			go h.HarvestNow(h.config.Context)
+		case <-h.config.Context.Done():
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
At the moment there is no way to stop the harvester from running as it uses its own background context. Added a new config variable so a context can be passed to the client. The "tick" in `harvester.harvestRoutine` can now be cancelled by the user. 