### PR TITLE
Add preliminary OpenTelemetry span event support

### DIFF
--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -95,6 +95,16 @@ func wrapHandler(path string, handler func(http.ResponseWriter, *http.Request)) 
 				"http.method": req.Method,
 				"isWeb":       true,
 			},
+			Events: []telemetry.Event{
+				telemetry.Event{
+					Name: "exception",
+					Timestamp: before,
+					Attributes: map[string]interface{}{
+						"exception.message": "Everything is fine!",
+						"exception.type": "java.lang.EverythingIsFine",
+					},
+				},
+			},
 		})
 	}
 }

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -97,11 +97,11 @@ func wrapHandler(path string, handler func(http.ResponseWriter, *http.Request)) 
 			},
 			Events: []telemetry.Event{
 				telemetry.Event{
-					Name: "exception",
+					Name:      "exception",
 					Timestamp: before,
 					Attributes: map[string]interface{}{
 						"exception.message": "Everything is fine!",
-						"exception.type": "java.lang.EverythingIsFine",
+						"exception.type":    "java.lang.EverythingIsFine",
 					},
 				},
 			},

--- a/internal/json_writer.go
+++ b/internal/json_writer.go
@@ -34,6 +34,12 @@ func (w *JSONFieldsWriter) AddKey(key string) {
 	w.Buf.WriteByte(':')
 }
 
+// Call this to ensure that a comma won't be added before the next field this
+// JsonFieldsWriter writes.
+func (w *JSONFieldsWriter) NoComma() {
+	w.needsComma = false
+}
+
 // StringField adds a string field to the object.
 func (w *JSONFieldsWriter) StringField(key string, val string) {
 	w.AddKey(key)

--- a/internal/json_writer.go
+++ b/internal/json_writer.go
@@ -34,7 +34,7 @@ func (w *JSONFieldsWriter) AddKey(key string) {
 	w.Buf.WriteByte(':')
 }
 
-// Call this to ensure that a comma won't be added before the next field this
+// NoComma ensures that a comma won't be added before the next field this
 // JsonFieldsWriter writes.
 func (w *JSONFieldsWriter) NoComma() {
 	w.needsComma = false

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -34,6 +34,16 @@ Record metrics and/or spans.
     Attributes: map[string]interface{}{
       "color": "purple",
     },
+    Events: []Event{
+			Event{
+				Name:      "Series",
+				Timestamp: tm,
+				Attributes: map[string]interface{}{
+					"exception.message": "Unfortunate event occurred",
+					"exception.type":    "Unfortunate",
+				},
+			},
+		},
   })
   ```
 

--- a/telemetry/spans.go
+++ b/telemetry/spans.go
@@ -45,7 +45,7 @@ type Span struct {
 	// AttributesJSON is a json.RawMessage of attributes for this metric. It
 	// will only be sent if Attributes is nil.
 	AttributesJSON json.RawMessage
-	// Events is an array of events that occured during the execution of a span.
+	// Events is a slice of events that occurred during the execution of a span.
 	// This feature is a work in progress.
 	Events []Event
 }
@@ -103,7 +103,7 @@ func (s *Span) writeJSON(buf *bytes.Buffer) {
 }
 
 type Event struct {
-	// Required Fields:
+	// Name is the identifier of an Event.
 	Name string
 	// Timestamp is when the event occurred. It should be after the Timestamp of its
 	// containing Span, and before the containing spans Timestamp + Duration.

--- a/telemetry/spans_test.go
+++ b/telemetry/spans_test.go
@@ -148,21 +148,6 @@ func TestRecordSpanNilHarvester(t *testing.T) {
 	}
 }
 
-func TestEvents(t *testing.T) {
-	tm := time.Date(2020, time.November, 13, 1, 1, 0, 0, time.UTC)
-	event := Event{
-		Name:      "exception",
-		Timestamp: tm,
-		Attributes: map[string]interface{}{
-			"exception.message": "Everything is fine!",
-		},
-	}
-
-	if event.Name != "exception" {
-		t.Errorf("\nexpect=%s\nactual=%s\n", "exception", event.Name)
-	}
-}
-
 func TestSpanWithEvents(t *testing.T) {
 	tm := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
 	h, _ := NewHarvester(configTesting)

--- a/telemetry/spans_test.go
+++ b/telemetry/spans_test.go
@@ -147,3 +147,65 @@ func TestRecordSpanNilHarvester(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestEvents(t *testing.T) {
+	tm := time.Date(2020, time.November, 13, 1, 1, 0, 0, time.UTC)
+	event := Event{
+		Name: "exception",
+		Timestamp: tm,
+		Attributes: map[string]interface{}{
+			"exception.message": "Everything is fine!",
+		},
+	}
+
+	if event.Name != "exception" {
+		t.Errorf("\nexpect=%s\nactual=%s\n", "exception", event.Name)
+	}
+}
+
+func TestSpanWithEvents(t *testing.T) {
+	tm := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
+	h, _ := NewHarvester(configTesting)
+	h.RecordSpan(Span{
+		ID:          "myid",
+		TraceID:     "mytraceid",
+		Name:        "myname",
+		ParentID:    "myparent",
+		Timestamp:   tm,
+		Duration:    2 * time.Second,
+		ServiceName: "myentity",
+		Attributes: map[string]interface{}{},
+		Events: []Event{
+			Event{
+				Name: "exception",
+				Timestamp: tm,
+				Attributes: map[string]interface{}{
+					"exception.message": "Everything is fine!",
+					"exception.type": "java.lang.EverythingIsFine",
+				},
+			},
+		},
+	})
+	expect := `[{"common":{},"spans":[{
+		"id":"myid",
+		"trace.id":"mytraceid",
+		"timestamp":1417136460000,
+		"attributes": {
+			"name":"myname",
+			"parent.id":"myparent",
+			"duration.ms":2000,
+			"service.name":"myentity"
+		},
+		"events": [
+			{
+				"name": "exception",
+				"timestamp": 1417136460000,
+				"attributes": {
+					"exception.message": "Everything is fine!",
+					"exception.type": "java.lang.EverythingIsFine"
+				}
+			}
+		]
+	}]}]`
+	testHarvesterSpans(t, h, expect)
+}

--- a/telemetry/spans_test.go
+++ b/telemetry/spans_test.go
@@ -151,7 +151,7 @@ func TestRecordSpanNilHarvester(t *testing.T) {
 func TestEvents(t *testing.T) {
 	tm := time.Date(2020, time.November, 13, 1, 1, 0, 0, time.UTC)
 	event := Event{
-		Name: "exception",
+		Name:      "exception",
 		Timestamp: tm,
 		Attributes: map[string]interface{}{
 			"exception.message": "Everything is fine!",
@@ -174,14 +174,14 @@ func TestSpanWithEvents(t *testing.T) {
 		Timestamp:   tm,
 		Duration:    2 * time.Second,
 		ServiceName: "myentity",
-		Attributes: map[string]interface{}{},
+		Attributes:  map[string]interface{}{},
 		Events: []Event{
 			Event{
-				Name: "exception",
+				Name:      "exception",
 				Timestamp: tm,
 				Attributes: map[string]interface{}{
 					"exception.message": "Everything is fine!",
-					"exception.type": "java.lang.EverythingIsFine",
+					"exception.type":    "java.lang.EverythingIsFine",
 				},
 			},
 		},


### PR DESCRIPTION
This PR attempts to add support for OpenTelemetry span events. 
See also: the [OpenTelemetry API spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#add-events) and [proto](https://github.com/open-telemetry/opentelemetry-proto/blob/master/opentelemetry/proto/trace/v1/trace.proto#L169).

This is a prototype of potential support for SpanEvents; the format described here is not yet supported by the New Relic trace API.

@MrAlias 