### PR TITLE
Remove Insights branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Go 1.7+ is required
 
 ## Get started
 
-In order to send metrics or spans to New Relic, you will need an [Insights
-Insert API Key](https://docs.newrelic.com/docs/apis/getting-started/intro-apis/understand-new-relic-api-keys#user-api-key).
+In order to send metrics or spans to New Relic, you will need an [Insert API Key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#event-insert-key).
 
 To install this SDK either use `go get` or clone this repository to
 `$GOPATH/src/github.com/newrelic/newrelic-telemetry-sdk-go`
@@ -32,8 +31,8 @@ automatic harvesting on a given schedule, and handling of errors from the API
 response.  It also provides the ability to aggregate individual data points into
 metrics.
 
-This example code assumes you've set the the `NEW_RELIC_INSIGHTS_INSERT_API_KEY`
-environment variable to your Insights Insert API Key.  A larger example is
+This example code assumes you've set the the `NEW_RELIC_INSERT_API_KEY`
+environment variable to your Insert API Key.  A larger example is
 provided in
 [examples/server/main.go](./examples/server/main.go).
 
@@ -51,7 +50,7 @@ import (
 
 func main() {
 	// First create a Harvester.  APIKey is the only required field.
-	h, err := telemetry.NewHarvester(telemetry.ConfigAPIKey(os.Getenv("NEW_RELIC_INSIGHTS_INSERT_API_KEY")))
+	h, err := telemetry.NewHarvester(telemetry.ConfigAPIKey(os.Getenv("NEW_RELIC_INSERT_API_KEY")))
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/cumulative/cumulative_test.go
+++ b/cumulative/cumulative_test.go
@@ -17,7 +17,7 @@ import (
 
 func Example() {
 	h, err := telemetry.NewHarvester(
-		telemetry.ConfigAPIKey(os.Getenv("NEW_RELIC_INSIGHTS_INSERT_API_KEY")),
+		telemetry.ConfigAPIKey(os.Getenv("NEW_RELIC_INSERT_API_KEY")),
 	)
 	if err != nil {
 		fmt.Println(err)

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -122,7 +122,7 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 	var err error
 	h, err = telemetry.NewHarvester(
-		telemetry.ConfigAPIKey(mustGetEnv("NEW_RELIC_INSIGHTS_INSERT_API_KEY")),
+		telemetry.ConfigAPIKey(mustGetEnv("NEW_RELIC_INSERT_API_KEY")),
 		telemetry.ConfigCommonAttributes(map[string]interface{}{
 			"app.name":  "myServer",
 			"host.name": "dev.server.com",

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -11,7 +11,7 @@ the background.
 
   ```go
   harvester := telemetry.NewHarvester(
-    telemetry.ConfigAPIKey(os.Getenv("NEW_RELIC_INSIGHTS_INSERT_API_KEY")),
+    telemetry.ConfigAPIKey(os.Getenv("NEW_RELIC_INSERT_API_KEY")),
   )
   ```
 

--- a/telemetry/aggregated_metrics_test.go
+++ b/telemetry/aggregated_metrics_test.go
@@ -78,19 +78,19 @@ func BenchmarkAggregatedMetric(b *testing.B) {
 }
 
 func ExampleMetricAggregator_Count() {
-	h, _ := NewHarvester(ConfigAPIKey(os.Getenv("NEW_RELIC_INSIGHTS_INSERT_API_KEY")))
+	h, _ := NewHarvester(ConfigAPIKey(os.Getenv("NEW_RELIC_INSERT_API_KEY")))
 	count := h.MetricAggregator().Count("myCount", map[string]interface{}{"zip": "zap"})
 	count.Increment()
 }
 
 func ExampleMetricAggregator_Gauge() {
-	h, _ := NewHarvester(ConfigAPIKey(os.Getenv("NEW_RELIC_INSIGHTS_INSERT_API_KEY")))
+	h, _ := NewHarvester(ConfigAPIKey(os.Getenv("NEW_RELIC_INSERT_API_KEY")))
 	gauge := h.MetricAggregator().Gauge("temperature", map[string]interface{}{"zip": "zap"})
 	gauge.Value(23.4)
 }
 
 func ExampleMetricAggregator_Summary() {
-	h, _ := NewHarvester(ConfigAPIKey(os.Getenv("NEW_RELIC_INSIGHTS_INSERT_API_KEY")))
+	h, _ := NewHarvester(ConfigAPIKey(os.Getenv("NEW_RELIC_INSERT_API_KEY")))
 	summary := h.MetricAggregator().Summary("mySummary", map[string]interface{}{"zip": "zap"})
 	summary.RecordDuration(3 * time.Second)
 }

--- a/telemetry/config.go
+++ b/telemetry/config.go
@@ -13,7 +13,7 @@ import (
 
 // Config customizes the behavior of a Harvester.
 type Config struct {
-	// APIKey is required  and refers to your New Relic Insights Insert API key.
+	// APIKey is required and refers to your New Relic Insert API key.
 	APIKey string
 	// Client is the http.Client used for making requests.
 	Client *http.Client
@@ -52,7 +52,7 @@ type Config struct {
 }
 
 // ConfigAPIKey sets the Config's APIKey which is required and refers to your
-// New Relic Insights Insert API key.
+// New Relic Insert API key.
 func ConfigAPIKey(key string) func(*Config) {
 	return func(cfg *Config) {
 		cfg.APIKey = key

--- a/telemetry/example_test.go
+++ b/telemetry/example_test.go
@@ -12,8 +12,8 @@ import (
 
 func Example() {
 	h, err := NewHarvester(
-		// APIKey is the only required field and refers to your New Relic Insights Insert API key.
-		ConfigAPIKey(os.Getenv("NEW_RELIC_INSIGHTS_INSERT_API_KEY")),
+		// APIKey is the only required field and refers to your New Relic Insert API key.
+		ConfigAPIKey(os.Getenv("NEW_RELIC_INSERT_API_KEY")),
 		ConfigCommonAttributes(map[string]interface{}{
 			"app.name": "myApplication",
 		}),
@@ -61,7 +61,7 @@ func Example() {
 
 func ExampleNewHarvester() {
 	h, err := NewHarvester(
-		ConfigAPIKey(os.Getenv("NEW_RELIC_INSIGHTS_INSERT_API_KEY")),
+		ConfigAPIKey(os.Getenv("NEW_RELIC_INSERT_API_KEY")),
 	)
 	if err != nil {
 		fmt.Println(err)
@@ -78,7 +78,7 @@ func ExampleNewHarvester() {
 
 func ExampleHarvester_RecordMetric() {
 	h, _ := NewHarvester(
-		ConfigAPIKey(os.Getenv("NEW_RELIC_INSIGHTS_INSERT_API_KEY")),
+		ConfigAPIKey(os.Getenv("NEW_RELIC_INSERT_API_KEY")),
 	)
 	start := time.Now()
 	h.RecordMetric(Count{
@@ -92,7 +92,7 @@ func ExampleHarvester_RecordMetric() {
 
 func ExampleConfigSpansURLOverride() {
 	h, _ := NewHarvester(
-		ConfigAPIKey(os.Getenv("NEW_RELIC_INSIGHTS_INSERT_API_KEY")),
+		ConfigAPIKey(os.Getenv("NEW_RELIC_INSERT_API_KEY")),
 		// Use ConfigSpansURLOverride to enable Infinite Tracing on the New
 		// Relic Edge by passing it your Trace Observer URL, including scheme
 		// and path.


### PR DESCRIPTION
New Relic is standardizing the names of their APIs. This removes the "Insights" branding and points the developer to the correct place in the documentation to get an Insert API Key to use with the Events API.