### PR TITLE
V0.5.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,42 @@
-## ChangeLog
+# ChangeLog
 
-## 0.4.0
+All notable changes to this project will be documented in this file.
 
-* Fixed bug in request retrying that resulted in the a zero length request
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.5.0] - 2020-11-18
+### Added
+- Implemented preliminary OpenTelemetry span support. (#31)
+
+## [0.4.0] - 2020-08-04
+### Fixed
+- Fixed bug in request retrying that resulted in the a zero length request
 body and manifested as an error mismatch in body length and Content-Length
-header.
+header. (#17)
 
-## 0.3.0
+## [0.3.0] - 2020-06-12
+### Added
+- Added `ConfigSpansURLOverride` to facilitate setting the Trace Observer URL
+for Infinite Tracing on the New Relic Edge. (#15)
 
-* Added `ConfigSpansURLOverride` to facilitate setting the Trace Observer URL
-  for Infinite Tracing on the New Relic Edge.
+## [0.2.0] - 2019-12-26
+### Fixed
+- The SDK will now check metrics for infinity and NaN.  Metrics with invalid
+values will be rejected, and will result in an error logged. (#3)
 
-## 0.2.0
+### Added
+- Added `Config.Product` and `Config.ProductVersion` fields which are
+used to the `User-Agent` header if set. (#2)
 
-* The SDK will now check metrics for infinity and NaN.  Metrics with invalid
-values will be rejected, and will result in an error logged.
-
-* Added `Config.Product` and `Config.ProductVersion` fields which are
-used to the `User-Agent` header if set.
-
-## 0.1.0
-
+## [0.1.0]
 First release!
+
+
+[Unreleased]: https://github.com/newrelic/newrelic-telemetry-sdk-go/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/newrelic/newrelic-telemetry-sdk-go/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/newrelic/newrelic-telemetry-sdk-go/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/newrelic/newrelic-telemetry-sdk-go/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/newrelic/newrelic-telemetry-sdk-go/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/newrelic/newrelic-telemetry-sdk-go/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Thanks for your interest in contributing to the Telemetry SDK! We look forward t
     * [golint](https://github.com/golang/lint)
     * [go vet](https://golang.org/cmd/vet/)
     * [go fmt](https://golang.org/cmd/gofmt/)
+  * If this is a notable change, please include a very short summary of your work in the "Unreleased" section of [CHANGELOG.md](./CHANGELOG.MD).
   * Sign the [Contributor Licensing Agreement](#contributor-license-agreement-cla), if you haven't already done so. (You will be prompted if we don't have a signed CLA already recorded.)
 
 ## How to Get Help or Ask Questions


### PR DESCRIPTION
Added new section for v0.5.0 concerning new events on spans functionality.

Reformatted the CHANGELOG.md to comply with the format in [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).

Reminded everybody to maintin the CHANGELOG.md file in the "## How to Contribute" section of the CONTRIBUTION.md file.