### PR TITLE
Use MB for maxCompressedSizeBytes instead of MiB

### DIFF
--- a/telemetry/request.go
+++ b/telemetry/request.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	maxCompressedSizeBytes = 1 << 20
+	maxCompressedSizeBytes = 1e6
 )
 
 // request contains an http.Request and the UncompressedBody which is provided


### PR DESCRIPTION
[Telemetry API](https://docs.newrelic.com/docs/telemetry-data-platform/get-data/apis/metric-api-limits-restricted-attributes) is checking for 1MB instead of 1MiB. This was causing sporadic data loss in nri-prometheus with a 413 Entity too long error. 

Fixes #38 