### PR TITLE
Github Actions-based CI Testing

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,52 @@
+# Copyright 2020 New Relic Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Go Telemetry SDK CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  test:
+    runs-on: ubuntu-18.04
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - go-version: 1.13
+          - go-version: 1.14
+          - go-version: 1.15
+          - go-version: 1.16
+    
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Fmt
+      run: go fmt ./...
+
+    - name: Vet
+      run: go vet ./...
+      env:
+        CGO_ENABLED: 0
+
+    - name: Lint
+      run: go get -u golang.org/x/lint/golint; /github/home/go/bin/golint -set_exit_status ./...
+
+    - name: Test
+      run: go test -benchtime=1ms -bench=. ./...
+      env:
+        CGO_ENABLED: 0
+


### PR DESCRIPTION
Works locally using [`act`](https://github.com/nektos/act). Runs `go build`. `go fmt`, `go vet`, `golint`, and `go test` on go 1.13, 1.14, 1.15, 1.16.