### PR TITLE
Build request contract

### DIFF
--- a/telemetry/attributes.go
+++ b/telemetry/attributes.go
@@ -21,7 +21,7 @@ func attributeValueValid(val interface{}) bool {
 }
 
 // vetAttributes returns the attributes that are valid.  vetAttributes does not
-// modify remove any elements from its parameter.
+// modify or remove any elements from its parameter.
 func vetAttributes(attributes map[string]interface{}) (map[string]interface{}, error) {
 	valid := true
 	for _, val := range attributes {
@@ -59,14 +59,17 @@ func (ca *commonAttributes) Bytes() []byte {
 	return ca.RawJSON
 }
 
+// newCommonAttributes vets and marshals the attributes map. If invalid attributes are
+// detected, the response will contain the valid attributes and an error describing which
+// keys were invalid. If a marshalling error occurs, nil  commonAttributes and an error
+// will be returned.
 func newCommonAttributes(attributes map[string]interface{}) (*commonAttributes, error) {
-	attrs, err := vetAttributes(attributes)
-	if err != nil {
-		return nil, err
+	response := commonAttributes{}
+	validAttrs, err := vetAttributes(attributes)
+	validAttrsJSON, marshalErr := json.Marshal(validAttrs)
+	if marshalErr != nil {
+		return nil, marshalErr
 	}
-	attributesJSON, err := json.Marshal(attrs)
-	if err != nil {
-		return nil, err
-	}
-	return &commonAttributes{RawJSON: attributesJSON}, nil
+	response.RawJSON = validAttrsJSON
+	return &response, err
 }

--- a/telemetry/attributes.go
+++ b/telemetry/attributes.go
@@ -58,11 +58,11 @@ func (ca *commonAttributes) Bytes() []byte {
 	return ca.RawJSON
 }
 
-func newCommonAttributes(attributes map[string]interface{}, errorLogger func(map[string]interface{})) (*commonAttributes) {
+func newCommonAttributes(attributes map[string]interface{}, errorLogger func(map[string]interface{})) *commonAttributes {
 	attrs := vetAttributes(attributes, errorLogger)
 	attributesJSON, err := json.Marshal(attrs)
 
-	if (err != nil) {
+	if err != nil {
 		errorLogger(map[string]interface{}{
 			"err":     err.Error(),
 			"message": "error marshaling common attributes",

--- a/telemetry/attributes.go
+++ b/telemetry/attributes.go
@@ -5,7 +5,9 @@ package telemetry
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 )
 
 func attributeValueValid(val interface{}) bool {
@@ -20,7 +22,7 @@ func attributeValueValid(val interface{}) bool {
 
 // vetAttributes returns the attributes that are valid.  vetAttributes does not
 // modify remove any elements from its parameter.
-func vetAttributes(attributes map[string]interface{}, errorLogger func(map[string]interface{})) map[string]interface{} {
+func vetAttributes(attributes map[string]interface{}) (map[string]interface{}, error) {
 	valid := true
 	for _, val := range attributes {
 		if !attributeValueValid(val) {
@@ -29,21 +31,20 @@ func vetAttributes(attributes map[string]interface{}, errorLogger func(map[strin
 		}
 	}
 	if valid {
-		return attributes
+		return attributes, nil
 	}
 	// Note that the map is only copied if elements are to be removed to
 	// improve performance.
 	validAttributes := make(map[string]interface{}, len(attributes))
+	var errStrs []string
 	for key, val := range attributes {
 		if attributeValueValid(val) {
 			validAttributes[key] = val
-		} else if nil != errorLogger {
-			errorLogger(map[string]interface{}{
-				"err": fmt.Sprintf(`attribute "%s" has invalid type %T`, key, val),
-			})
+		} else {
+			errStrs = append(errStrs, fmt.Sprintf(`attribute "%s" has invalid type %T`, key, val))
 		}
 	}
-	return validAttributes
+	return validAttributes, errors.New(strings.Join(errStrs, ","))
 }
 
 type commonAttributes struct {
@@ -58,16 +59,14 @@ func (ca *commonAttributes) Bytes() []byte {
 	return ca.RawJSON
 }
 
-func newCommonAttributes(attributes map[string]interface{}, errorLogger func(map[string]interface{})) *commonAttributes {
-	attrs := vetAttributes(attributes, errorLogger)
-	attributesJSON, err := json.Marshal(attrs)
-
+func newCommonAttributes(attributes map[string]interface{}) (*commonAttributes, error) {
+	attrs, err := vetAttributes(attributes)
 	if err != nil {
-		errorLogger(map[string]interface{}{
-			"err":     err.Error(),
-			"message": "error marshaling common attributes",
-		})
-		return nil
+		return nil, err
 	}
-	return &commonAttributes{RawJSON: attributesJSON}
+	attributesJSON, err := json.Marshal(attrs)
+	if err != nil {
+		return nil, err
+	}
+	return &commonAttributes{RawJSON: attributesJSON}, nil
 }

--- a/telemetry/common.go
+++ b/telemetry/common.go
@@ -1,1 +1,0 @@
-package telemetry

--- a/telemetry/common.go
+++ b/telemetry/common.go
@@ -1,0 +1,1 @@
+package telemetry

--- a/telemetry/events.go
+++ b/telemetry/events.go
@@ -78,12 +78,12 @@ func (batch *eventBatch) makeBody() json.RawMessage {
 	return buf.Bytes()
 }
 
-// Type returns the type of data contained in this PayloadEntry.
+// Type returns the type of data contained in this MapEntry.
 func (batch *eventBatch) Type() string {
 	return eventTypeName
 }
 
-// Bytes returns the json serialized bytes of the PayloadEntry.
+// Bytes returns the json serialized bytes of the MapEntry.
 func (batch *eventBatch) Bytes() []byte {
 	buf := &bytes.Buffer{}
 	batch.writeJSON(buf)

--- a/telemetry/events.go
+++ b/telemetry/events.go
@@ -49,7 +49,7 @@ type eventBatch struct {
 
 // split will split the eventBatch into 2 equally sized batches.
 // If the number of events in the original is 0 or 1 then nil is returned.
-func (batch *eventBatch) split() []*eventBatch {
+func (batch *eventBatch) split() []splittablePayloadEntry {
 	if len(batch.Events) < 2 {
 		return nil
 	}
@@ -60,7 +60,7 @@ func (batch *eventBatch) split() []*eventBatch {
 	b2 := *batch
 	b2.Events = batch.Events[half:]
 
-	return []*eventBatch{&b1, &b2}
+	return []splittablePayloadEntry{&b1, &b2}
 }
 
 func (batch *eventBatch) writeJSON(buf *bytes.Buffer) {

--- a/telemetry/events_batch_test.go
+++ b/telemetry/events_batch_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
 )
 
-func testEventBatchJSON(t testing.TB, batches []PayloadBatch, expect string) {
+func testEventBatchJSON(t testing.TB, batches []Batch, expect string) {
 	if th, ok := t.(interface{ Helper() }); ok {
 		th.Helper()
 	}
@@ -68,8 +68,8 @@ func TestEventsPayloadSplit(t *testing.T) {
 		t.Error("split into incorrect number of slices", len(split))
 	}
 
-	testEventBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"eventType":"a","timestamp":-6795364578871}]`)
-	testEventBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"eventType":"b","timestamp":-6795364578871}]`)
+	testEventBatchJSON(t, []Batch{{split[0]}}, `[{"eventType":"a","timestamp":-6795364578871}]`)
+	testEventBatchJSON(t, []Batch{{split[1]}}, `[{"eventType":"b","timestamp":-6795364578871}]`)
 
 	// test len 3
 	ev = &eventBatch{Events: []Event{{EventType: "a"}, {EventType: "b"}, {EventType: "c"}}}
@@ -77,8 +77,8 @@ func TestEventsPayloadSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testEventBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"eventType":"a","timestamp":-6795364578871}]`)
-	testEventBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"eventType":"b","timestamp":-6795364578871},{"eventType":"c","timestamp":-6795364578871}]`)
+	testEventBatchJSON(t, []Batch{{split[0]}}, `[{"eventType":"a","timestamp":-6795364578871}]`)
+	testEventBatchJSON(t, []Batch{{split[1]}}, `[{"eventType":"b","timestamp":-6795364578871},{"eventType":"c","timestamp":-6795364578871}]`)
 }
 
 func TestEventsJSON(t *testing.T) {
@@ -95,7 +95,7 @@ func TestEventsJSON(t *testing.T) {
 	batch2 := &eventBatch{Events: []Event{{EventType: "a"}}}
 	batch3 := &eventBatch{Events: []Event{{EventType: "b"}}}
 
-	testEventBatchJSON(t, []PayloadBatch{{batch1, batch2}, {batch3}}, `[
+	testEventBatchJSON(t, []Batch{{batch1, batch2}, {batch3}}, `[
 		{
 		  "eventType":"",
 		  "timestamp":-6795364578871

--- a/telemetry/events_batch_test.go
+++ b/telemetry/events_batch_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
 )
 
-func testEventBatchJSON(t testing.TB, batch *eventBatch, expect string) {
+func testEventBatchJSON(t testing.TB, batches [][]PayloadEntry, expect string) {
 	if th, ok := t.(interface{ Helper() }); ok {
 		th.Helper()
 	}
 	factory, _ := NewEventRequestFactory(WithNoDefaultKey())
-	reqs, err := newRequests([]PayloadEntry{batch}, factory)
+	reqs, err := newRequests(batches, factory)
 	if nil != err {
 		t.Fatal(err)
 	}
@@ -68,8 +68,8 @@ func TestEventsPayloadSplit(t *testing.T) {
 		t.Error("split into incorrect number of slices", len(split))
 	}
 
-	testEventBatchJSON(t, split[0], `[{"eventType":"a","timestamp":-6795364578871}]`)
-	testEventBatchJSON(t, split[1], `[{"eventType":"b","timestamp":-6795364578871}]`)
+	testEventBatchJSON(t, [][]PayloadEntry{{split[0]}}, `[{"eventType":"a","timestamp":-6795364578871}]`)
+	testEventBatchJSON(t, [][]PayloadEntry{{split[1]}}, `[{"eventType":"b","timestamp":-6795364578871}]`)
 
 	// test len 3
 	ev = &eventBatch{Events: []Event{{EventType: "a"}, {EventType: "b"}, {EventType: "c"}}}
@@ -77,14 +77,14 @@ func TestEventsPayloadSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testEventBatchJSON(t, split[0], `[{"eventType":"a","timestamp":-6795364578871}]`)
-	testEventBatchJSON(t, split[1], `[{"eventType":"b","timestamp":-6795364578871},{"eventType":"c","timestamp":-6795364578871}]`)
+	testEventBatchJSON(t, [][]PayloadEntry{{split[0]}}, `[{"eventType":"a","timestamp":-6795364578871}]`)
+	testEventBatchJSON(t, [][]PayloadEntry{{split[1]}}, `[{"eventType":"b","timestamp":-6795364578871},{"eventType":"c","timestamp":-6795364578871}]`)
 }
 
 func TestEventsJSON(t *testing.T) {
 	t.Parallel()
 
-	batch := &eventBatch{Events: []Event{
+	batch1 := &eventBatch{Events: []Event{
 		{}, // Empty
 		{ // with everything
 			EventType:  "testEvent",
@@ -92,16 +92,26 @@ func TestEventsJSON(t *testing.T) {
 			Attributes: map[string]interface{}{"zip": "zap"},
 		},
 	}}
+	batch2 := &eventBatch{Events: []Event{{EventType: "a"}}}
+	batch3 := &eventBatch{Events: []Event{{EventType: "b"}}}
 
-	testEventBatchJSON(t, batch, `[
+	testEventBatchJSON(t, [][]PayloadEntry{{batch1, batch2}, {batch3}}, `[
 		{
 		  "eventType":"",
-			"timestamp":-6795364578871
+		  "timestamp":-6795364578871
 		},
 		{
 			"eventType":"testEvent",
 			"timestamp":1417136460000,
 			"zip":"zap"
+		},
+		{
+		  "eventType":"a",
+		  "timestamp":-6795364578871
+		},
+		{
+		  "eventType":"b",
+		  "timestamp":-6795364578871
 		}
 	]`)
 }

--- a/telemetry/events_batch_test.go
+++ b/telemetry/events_batch_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
 )
 
-func testEventBatchJSON(t testing.TB, batches [][]PayloadEntry, expect string) {
+func testEventBatchJSON(t testing.TB, batches []PayloadBatch, expect string) {
 	if th, ok := t.(interface{ Helper() }); ok {
 		th.Helper()
 	}
@@ -68,8 +68,8 @@ func TestEventsPayloadSplit(t *testing.T) {
 		t.Error("split into incorrect number of slices", len(split))
 	}
 
-	testEventBatchJSON(t, [][]PayloadEntry{{split[0]}}, `[{"eventType":"a","timestamp":-6795364578871}]`)
-	testEventBatchJSON(t, [][]PayloadEntry{{split[1]}}, `[{"eventType":"b","timestamp":-6795364578871}]`)
+	testEventBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"eventType":"a","timestamp":-6795364578871}]`)
+	testEventBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"eventType":"b","timestamp":-6795364578871}]`)
 
 	// test len 3
 	ev = &eventBatch{Events: []Event{{EventType: "a"}, {EventType: "b"}, {EventType: "c"}}}
@@ -77,8 +77,8 @@ func TestEventsPayloadSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testEventBatchJSON(t, [][]PayloadEntry{{split[0]}}, `[{"eventType":"a","timestamp":-6795364578871}]`)
-	testEventBatchJSON(t, [][]PayloadEntry{{split[1]}}, `[{"eventType":"b","timestamp":-6795364578871},{"eventType":"c","timestamp":-6795364578871}]`)
+	testEventBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"eventType":"a","timestamp":-6795364578871}]`)
+	testEventBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"eventType":"b","timestamp":-6795364578871},{"eventType":"c","timestamp":-6795364578871}]`)
 }
 
 func TestEventsJSON(t *testing.T) {
@@ -95,7 +95,7 @@ func TestEventsJSON(t *testing.T) {
 	batch2 := &eventBatch{Events: []Event{{EventType: "a"}}}
 	batch3 := &eventBatch{Events: []Event{{EventType: "b"}}}
 
-	testEventBatchJSON(t, [][]PayloadEntry{{batch1, batch2}, {batch3}}, `[
+	testEventBatchJSON(t, []PayloadBatch{{batch1, batch2}, {batch3}}, `[
 		{
 		  "eventType":"",
 		  "timestamp":-6795364578871

--- a/telemetry/events_batch_test.go
+++ b/telemetry/events_batch_test.go
@@ -115,3 +115,8 @@ func TestEventsJSON(t *testing.T) {
 		}
 	]`)
 }
+
+func TestEventBatchSplittable(t *testing.T) {
+	batch := &eventBatch{Events: []Event{{EventType: "a"}}}
+	_ = splittablePayloadEntry(batch)
+}

--- a/telemetry/harvester.go
+++ b/telemetry/harvester.go
@@ -74,7 +74,11 @@ func NewHarvester(options ...func(*Config)) (*Harvester, error) {
 	// the consumer modifies the CommonAttributes map after calling
 	// NewHarvester.
 	if nil != h.config.CommonAttributes {
-		h.commonAttributes = newCommonAttributes(h.config.CommonAttributes, h.config.logError)
+		commonAttributes, err := newCommonAttributes(h.config.CommonAttributes)
+		if err != nil {
+			h.config.logError(map[string]interface{}{"err": err.Error()})
+		}
+		h.commonAttributes = commonAttributes
 		h.config.CommonAttributes = nil
 	}
 
@@ -351,7 +355,7 @@ func (h *Harvester) swapOutSpans() []*http.Request {
 
 	entries := []PayloadEntry{}
 	if nil != h.commonAttributes {
-		entries = append(entries, &spanCommonBlock{Attributes: h.commonAttributes})
+		entries = append(entries, &SpanCommonBlock{Attributes: h.commonAttributes})
 	}
 	entries = append(entries, &SpanBatch{Spans: sps})
 	reqs, err := newRequests([][]PayloadEntry{entries}, h.spanRequestFactory)

--- a/telemetry/harvester.go
+++ b/telemetry/harvester.go
@@ -355,7 +355,7 @@ func (h *Harvester) swapOutSpans() []*http.Request {
 
 	entries := []PayloadEntry{}
 	if nil != h.commonAttributes {
-		entries = append(entries, &SpanCommonBlock{Attributes: h.commonAttributes})
+		entries = append(entries, &spanCommonBlock{Attributes: h.commonAttributes})
 	}
 	entries = append(entries, &SpanBatch{Spans: sps})
 	reqs, err := newRequests([][]PayloadEntry{entries}, h.spanRequestFactory)

--- a/telemetry/harvester.go
+++ b/telemetry/harvester.go
@@ -328,7 +328,7 @@ func (h *Harvester) swapOutMetrics(now time.Time) []*http.Request {
 	}
 	batch := &MetricBatch{Metrics: rawMetrics}
 	entries := []PayloadEntry{commonBlock, batch}
-	reqs, err := newRequests(entries, h.metricRequestFactory)
+	reqs, err := newRequests([][]PayloadEntry{entries}, h.metricRequestFactory)
 	if nil != err {
 		h.config.logError(map[string]interface{}{
 			"err":     err.Error(),
@@ -354,7 +354,7 @@ func (h *Harvester) swapOutSpans() []*http.Request {
 		entries = append(entries, &spanCommonBlock{Attributes: h.commonAttributes})
 	}
 	entries = append(entries, &SpanBatch{Spans: sps})
-	reqs, err := newRequests(entries, h.spanRequestFactory)
+	reqs, err := newRequests([][]PayloadEntry{entries}, h.spanRequestFactory)
 	if nil != err {
 		h.config.logError(map[string]interface{}{
 			"err":     err.Error(),
@@ -377,8 +377,7 @@ func (h *Harvester) swapOutEvents() []*http.Request {
 	batch := &eventBatch{
 		Events: events,
 	}
-	entries := []PayloadEntry{batch}
-	reqs, err := newRequests(entries, h.eventRequestFactory)
+	reqs, err := newRequests([][]PayloadEntry{{batch}}, h.eventRequestFactory)
 	if nil != err {
 		h.config.logError(map[string]interface{}{
 			"err":     err.Error(),
@@ -404,7 +403,7 @@ func (h *Harvester) swapOutLogs() []*http.Request {
 		entries = append(entries, &logCommonBlock{Attributes: h.commonAttributes})
 	}
 	entries = append(entries, &LogBatch{Logs: logs})
-	reqs, err := newRequests(entries, h.logRequestFactory)
+	reqs, err := newRequests([][]PayloadEntry{entries}, h.logRequestFactory)
 	if nil != err {
 		h.config.logError(map[string]interface{}{
 			"err":     err.Error(),

--- a/telemetry/harvester.go
+++ b/telemetry/harvester.go
@@ -355,7 +355,7 @@ func (h *Harvester) swapOutSpans() []*http.Request {
 
 	entries := []MapEntry{}
 	if nil != h.commonAttributes {
-		entries = append(entries, &spanCommonBlock{Attributes: h.commonAttributes})
+		entries = append(entries, &spanCommonBlock{attributes: h.commonAttributes})
 	}
 	entries = append(entries, &SpanBatch{Spans: sps})
 	reqs, err := newRequests([]Batch{entries}, h.spanRequestFactory)

--- a/telemetry/harvester.go
+++ b/telemetry/harvester.go
@@ -332,7 +332,7 @@ func (h *Harvester) swapOutMetrics(now time.Time) []*http.Request {
 	}
 	batch := &MetricBatch{Metrics: rawMetrics}
 	entries := []PayloadEntry{commonBlock, batch}
-	reqs, err := newRequests([][]PayloadEntry{entries}, h.metricRequestFactory)
+	reqs, err := newRequests([]PayloadBatch{entries}, h.metricRequestFactory)
 	if nil != err {
 		h.config.logError(map[string]interface{}{
 			"err":     err.Error(),
@@ -358,7 +358,7 @@ func (h *Harvester) swapOutSpans() []*http.Request {
 		entries = append(entries, &spanCommonBlock{Attributes: h.commonAttributes})
 	}
 	entries = append(entries, &SpanBatch{Spans: sps})
-	reqs, err := newRequests([][]PayloadEntry{entries}, h.spanRequestFactory)
+	reqs, err := newRequests([]PayloadBatch{entries}, h.spanRequestFactory)
 	if nil != err {
 		h.config.logError(map[string]interface{}{
 			"err":     err.Error(),
@@ -381,7 +381,7 @@ func (h *Harvester) swapOutEvents() []*http.Request {
 	batch := &eventBatch{
 		Events: events,
 	}
-	reqs, err := newRequests([][]PayloadEntry{{batch}}, h.eventRequestFactory)
+	reqs, err := newRequests([]PayloadBatch{{batch}}, h.eventRequestFactory)
 	if nil != err {
 		h.config.logError(map[string]interface{}{
 			"err":     err.Error(),
@@ -407,7 +407,7 @@ func (h *Harvester) swapOutLogs() []*http.Request {
 		entries = append(entries, &logCommonBlock{Attributes: h.commonAttributes})
 	}
 	entries = append(entries, &LogBatch{Logs: logs})
-	reqs, err := newRequests([][]PayloadEntry{entries}, h.logRequestFactory)
+	reqs, err := newRequests([]PayloadBatch{entries}, h.logRequestFactory)
 	if nil != err {
 		h.config.logError(map[string]interface{}{
 			"err":     err.Error(),

--- a/telemetry/harvester.go
+++ b/telemetry/harvester.go
@@ -331,8 +331,8 @@ func (h *Harvester) swapOutMetrics(now time.Time) []*http.Request {
 		Attributes: h.commonAttributes,
 	}
 	batch := &MetricBatch{Metrics: rawMetrics}
-	entries := []PayloadEntry{commonBlock, batch}
-	reqs, err := newRequests([]PayloadBatch{entries}, h.metricRequestFactory)
+	entries := []MapEntry{commonBlock, batch}
+	reqs, err := newRequests([]Batch{entries}, h.metricRequestFactory)
 	if nil != err {
 		h.config.logError(map[string]interface{}{
 			"err":     err.Error(),
@@ -353,12 +353,12 @@ func (h *Harvester) swapOutSpans() []*http.Request {
 		return nil
 	}
 
-	entries := []PayloadEntry{}
+	entries := []MapEntry{}
 	if nil != h.commonAttributes {
 		entries = append(entries, &spanCommonBlock{Attributes: h.commonAttributes})
 	}
 	entries = append(entries, &SpanBatch{Spans: sps})
-	reqs, err := newRequests([]PayloadBatch{entries}, h.spanRequestFactory)
+	reqs, err := newRequests([]Batch{entries}, h.spanRequestFactory)
 	if nil != err {
 		h.config.logError(map[string]interface{}{
 			"err":     err.Error(),
@@ -381,7 +381,7 @@ func (h *Harvester) swapOutEvents() []*http.Request {
 	batch := &eventBatch{
 		Events: events,
 	}
-	reqs, err := newRequests([]PayloadBatch{{batch}}, h.eventRequestFactory)
+	reqs, err := newRequests([]Batch{{batch}}, h.eventRequestFactory)
 	if nil != err {
 		h.config.logError(map[string]interface{}{
 			"err":     err.Error(),
@@ -402,12 +402,12 @@ func (h *Harvester) swapOutLogs() []*http.Request {
 		return nil
 	}
 
-	entries := []PayloadEntry{}
+	entries := []MapEntry{}
 	if nil != h.commonAttributes {
 		entries = append(entries, &logCommonBlock{Attributes: h.commonAttributes})
 	}
 	entries = append(entries, &LogBatch{Logs: logs})
-	reqs, err := newRequests([]PayloadBatch{entries}, h.logRequestFactory)
+	reqs, err := newRequests([]Batch{entries}, h.logRequestFactory)
 	if nil != err {
 		h.config.logError(map[string]interface{}{
 			"err":     err.Error(),

--- a/telemetry/harvester_test.go
+++ b/telemetry/harvester_test.go
@@ -115,15 +115,15 @@ func TestPathNotUsedFromUrls(t *testing.T) {
 }
 
 func validateReqUsedCorrectEndpointValues(reqs []*http.Request, expectedURL string, expectedEndpoint string, t *testing.T) {
-	if (len(reqs) < 1) {
+	if len(reqs) < 1 {
 		t.Error("Expected at least 1 requst to validate")
 	}
 
 	for _, req := range reqs {
-		if (req.Host != expectedEndpoint) {
+		if req.Host != expectedEndpoint {
 			t.Errorf("Got req.Host %v but expected %v", req.Host, expectedEndpoint)
 		}
-		if (req.URL.String() != expectedURL) {
+		if req.URL.String() != expectedURL {
 			t.Errorf("Got req.URL %v but expected %v", req.URL.String(), expectedURL)
 		}
 	}

--- a/telemetry/harvester_test.go
+++ b/telemetry/harvester_test.go
@@ -203,7 +203,15 @@ func TestVetCommonAttributes(t *testing.T) {
 			}
 		},
 	)
-	if len(savedErrors) != 3 {
+	if len(savedErrors) != 1 {
+		t.Fatalf("Expected one error but there was %v", len(savedErrors))
+	}
+	errVal, ok := savedErrors[0]["err"]
+	if !ok {
+		t.Fatalf("Missing expected err key.")
+	}
+	errors := strings.Split(errVal.(string), ",")
+	if len(errors) != 3 {
 		t.Fatal(savedErrors)
 	}
 }

--- a/telemetry/logs.go
+++ b/telemetry/logs.go
@@ -53,12 +53,12 @@ type logCommonBlock struct {
 	Attributes *commonAttributes
 }
 
-// Type returns the type of data contained in this PayloadEntry.
+// Type returns the type of data contained in this MapEntry.
 func (c *logCommonBlock) Type() string {
 	return "common"
 }
 
-// Bytes returns the json serialized bytes of the PayloadEntry.
+// Bytes returns the json serialized bytes of the MapEntry.
 func (c *logCommonBlock) Bytes() []byte {
 	buf := &bytes.Buffer{}
 	buf.WriteByte('{')
@@ -73,12 +73,12 @@ type LogBatch struct {
 	Logs []Log
 }
 
-// Type returns the type of data contained in this PayloadEntry.
+// Type returns the type of data contained in this MapEntry.
 func (batch *LogBatch) Type() string {
 	return logTypeName
 }
 
-// Bytes returns the json serialized bytes of the PayloadEntry.
+// Bytes returns the json serialized bytes of the MapEntry.
 func (batch *LogBatch) Bytes() []byte {
 	buf := &bytes.Buffer{}
 	buf.WriteByte('[')

--- a/telemetry/logs.go
+++ b/telemetry/logs.go
@@ -94,10 +94,10 @@ func (batch *LogBatch) Bytes() []byte {
 	return buf.Bytes()
 }
 
-func (batch *LogBatch) split() []*LogBatch {
+func (batch *LogBatch) split() []splittablePayloadEntry {
 	if len(batch.Logs) < 2 {
 		return nil
 	}
 	middle := len(batch.Logs) / 2
-	return []*LogBatch{{Logs: batch.Logs[0:middle]}, {Logs: batch.Logs[middle:]}}
+	return []splittablePayloadEntry{&LogBatch{Logs: batch.Logs[0:middle]}, &LogBatch{Logs: batch.Logs[middle:]}}
 }

--- a/telemetry/logs.go
+++ b/telemetry/logs.go
@@ -62,8 +62,10 @@ func (c *logCommonBlock) Type() string {
 func (c *logCommonBlock) Bytes() []byte {
 	buf := &bytes.Buffer{}
 	buf.WriteByte('{')
-	w := internal.JSONFieldsWriter{Buf: buf}
-	w.RawField(c.Attributes.Type(), c.Attributes.Bytes())
+	if c.Attributes != nil {
+		w := internal.JSONFieldsWriter{Buf: buf}
+		w.RawField(c.Attributes.Type(), c.Attributes.Bytes())
+	}
 	buf.WriteByte('}')
 	return buf.Bytes()
 }

--- a/telemetry/logs_batch_test.go
+++ b/telemetry/logs_batch_test.go
@@ -158,3 +158,15 @@ func TestLogsJSONWithCommonAttributesJSON(t *testing.T) {
 		}
 	]`)
 }
+
+func TestLogBatchSplittable(t *testing.T) {
+	batch := &LogBatch{
+		Logs: []Log{
+			{
+				Message:    "This is a log message.",
+				Timestamp:  time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC),
+				Attributes: map[string]interface{}{"zip": "zap"},
+			},
+		}}
+	_ = splittablePayloadEntry(batch)
+}

--- a/telemetry/logs_batch_test.go
+++ b/telemetry/logs_batch_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
 )
 
-func testLogBatchJSON(t testing.TB, batches [][]PayloadEntry, expect string) {
+func testLogBatchJSON(t testing.TB, batches []PayloadBatch, expect string) {
 	if th, ok := t.(interface{ Helper() }); ok {
 		th.Helper()
 	}
@@ -70,8 +70,8 @@ func TestLogsPayloadSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testLogBatchJSON(t, [][]PayloadEntry{{split[0]}}, `[{"logs":[{"message":"a","timestamp":-6795364578871,"attributes":{}}]}]`)
-	testLogBatchJSON(t, [][]PayloadEntry{{split[1]}}, `[{"logs":[{"message":"b","timestamp":-6795364578871,"attributes":{}}]}]`)
+	testLogBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"logs":[{"message":"a","timestamp":-6795364578871,"attributes":{}}]}]`)
+	testLogBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"logs":[{"message":"b","timestamp":-6795364578871,"attributes":{}}]}]`)
 
 	// test len 3
 	sp = &LogBatch{Logs: []Log{{Message: "a"}, {Message: "b"}, {Message: "c"}}}
@@ -79,8 +79,8 @@ func TestLogsPayloadSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testLogBatchJSON(t, [][]PayloadEntry{{split[0]}}, `[{"logs":[{"message":"a","timestamp":-6795364578871,"attributes":{}}]}]`)
-	testLogBatchJSON(t, [][]PayloadEntry{{split[1]}}, `[{"logs":[{"message":"b","timestamp":-6795364578871,"attributes":{}},{"message":"c","timestamp":-6795364578871,"attributes":{}}]}]`)
+	testLogBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"logs":[{"message":"a","timestamp":-6795364578871,"attributes":{}}]}]`)
+	testLogBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"logs":[{"message":"b","timestamp":-6795364578871,"attributes":{}},{"message":"c","timestamp":-6795364578871,"attributes":{}}]}]`)
 }
 
 func TestLogsJSON(t *testing.T) {
@@ -92,7 +92,7 @@ func TestLogsJSON(t *testing.T) {
 			Attributes: map[string]interface{}{"zip": "zap"},
 		},
 	}}
-	testLogBatchJSON(t, [][]PayloadEntry{{batch}}, `[{"logs":[
+	testLogBatchJSON(t, []PayloadBatch{{batch}}, `[{"logs":[
 		{
 			"message":"",
 			"timestamp":-6795364578871,
@@ -130,7 +130,7 @@ func TestLogsJSONWithCommonAttributesJSON(t *testing.T) {
 			},
 		},
 	}
-	testLogBatchJSON(t, [][]PayloadEntry{{commonBlock, batch1}, {batch2}}, `[
+	testLogBatchJSON(t, []PayloadBatch{{commonBlock, batch1}, {batch2}}, `[
 		{
 			"common": {
 				"attributes": {

--- a/telemetry/logs_batch_test.go
+++ b/telemetry/logs_batch_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
 )
 
-func testLogBatchJSON(t testing.TB, batches []PayloadBatch, expect string) {
+func testLogBatchJSON(t testing.TB, batches []Batch, expect string) {
 	if th, ok := t.(interface{ Helper() }); ok {
 		th.Helper()
 	}
@@ -70,8 +70,8 @@ func TestLogsPayloadSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testLogBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"logs":[{"message":"a","timestamp":-6795364578871,"attributes":{}}]}]`)
-	testLogBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"logs":[{"message":"b","timestamp":-6795364578871,"attributes":{}}]}]`)
+	testLogBatchJSON(t, []Batch{{split[0]}}, `[{"logs":[{"message":"a","timestamp":-6795364578871,"attributes":{}}]}]`)
+	testLogBatchJSON(t, []Batch{{split[1]}}, `[{"logs":[{"message":"b","timestamp":-6795364578871,"attributes":{}}]}]`)
 
 	// test len 3
 	sp = &LogBatch{Logs: []Log{{Message: "a"}, {Message: "b"}, {Message: "c"}}}
@@ -79,8 +79,8 @@ func TestLogsPayloadSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testLogBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"logs":[{"message":"a","timestamp":-6795364578871,"attributes":{}}]}]`)
-	testLogBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"logs":[{"message":"b","timestamp":-6795364578871,"attributes":{}},{"message":"c","timestamp":-6795364578871,"attributes":{}}]}]`)
+	testLogBatchJSON(t, []Batch{{split[0]}}, `[{"logs":[{"message":"a","timestamp":-6795364578871,"attributes":{}}]}]`)
+	testLogBatchJSON(t, []Batch{{split[1]}}, `[{"logs":[{"message":"b","timestamp":-6795364578871,"attributes":{}},{"message":"c","timestamp":-6795364578871,"attributes":{}}]}]`)
 }
 
 func TestLogsJSON(t *testing.T) {
@@ -92,7 +92,7 @@ func TestLogsJSON(t *testing.T) {
 			Attributes: map[string]interface{}{"zip": "zap"},
 		},
 	}}
-	testLogBatchJSON(t, []PayloadBatch{{batch}}, `[{"logs":[
+	testLogBatchJSON(t, []Batch{{batch}}, `[{"logs":[
 		{
 			"message":"",
 			"timestamp":-6795364578871,
@@ -130,7 +130,7 @@ func TestLogsJSONWithCommonAttributesJSON(t *testing.T) {
 			},
 		},
 	}
-	testLogBatchJSON(t, []PayloadBatch{{commonBlock, batch1}, {batch2}}, `[
+	testLogBatchJSON(t, []Batch{{commonBlock, batch1}, {batch2}}, `[
 		{
 			"common": {
 				"attributes": {

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -284,7 +284,7 @@ type MetricBatch struct {
 
 // split will split the MetricBatch into 2 equal parts, returning a slice of MetricBatches.
 // If the number of metrics in the original is 0 or 1 then nil is returned.
-func (batch *MetricBatch) split() []*MetricBatch {
+func (batch *MetricBatch) split() []splittablePayloadEntry {
 	if len(batch.Metrics) < 2 {
 		return nil
 	}
@@ -295,7 +295,7 @@ func (batch *MetricBatch) split() []*MetricBatch {
 	mb2 := *batch
 	mb2.Metrics = batch.Metrics[half:]
 
-	return []*MetricBatch{&mb1, &mb2}
+	return []splittablePayloadEntry{&mb1, &mb2}
 }
 
 // Type returns the type of data contained in this MapEntry.

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -249,12 +249,12 @@ type metricCommonBlock struct {
 	Attributes *commonAttributes
 }
 
-// Type returns the type of data contained in this PayloadEntry.
+// Type returns the type of data contained in this MapEntry.
 func (mcb *metricCommonBlock) Type() string {
 	return "common"
 }
 
-// Bytes returns the json serialized bytes of the PayloadEntry.
+// Bytes returns the json serialized bytes of the MapEntry.
 func (mcb *metricCommonBlock) Bytes() []byte {
 	buf := &bytes.Buffer{}
 	buf.WriteByte('{')
@@ -298,12 +298,12 @@ func (batch *MetricBatch) split() []*MetricBatch {
 	return []*MetricBatch{&mb1, &mb2}
 }
 
-// Type returns the type of data contained in this PayloadEntry.
+// Type returns the type of data contained in this MapEntry.
 func (batch *MetricBatch) Type() string {
 	return metricTypeName
 }
 
-// Bytes returns the json serialized bytes of the PayloadEntry.
+// Bytes returns the json serialized bytes of the MapEntry.
 func (batch *MetricBatch) Bytes() []byte {
 	buf := &bytes.Buffer{}
 	buf.WriteByte('[')

--- a/telemetry/metrics_batch_test.go
+++ b/telemetry/metrics_batch_test.go
@@ -82,7 +82,7 @@ func TestMetrics(t *testing.T) {
 	}]`)
 
 	factory, _ := NewMetricRequestFactory(WithNoDefaultKey())
-	reqs, err := newRequests([][]PayloadEntry{{commonBlock, metrics}}, factory)
+	reqs, err := newRequests([]PayloadBatch{{commonBlock, metrics}}, factory)
 	if err != nil {
 		t.Error("error creating request", err)
 	}
@@ -113,7 +113,7 @@ func TestMetrics(t *testing.T) {
 	}
 }
 
-func testBatchJSON(t testing.TB, batches [][]PayloadEntry, expect string) {
+func testBatchJSON(t testing.TB, batches []PayloadBatch, expect string) {
 	if th, ok := t.(interface{ Helper() }); ok {
 		th.Helper()
 	}
@@ -156,8 +156,8 @@ func TestSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testBatchJSON(t, [][]PayloadEntry{{split[0]}}, `[{"metrics":[{"name":"c1","type":"count","value":0}]}]`)
-	testBatchJSON(t, [][]PayloadEntry{{split[1]}}, `[{"metrics":[{"name":"c2","type":"count","value":0}]}]`)
+	testBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"metrics":[{"name":"c1","type":"count","value":0}]}]`)
+	testBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"metrics":[{"name":"c2","type":"count","value":0}]}]`)
 
 	// test len 3
 	batch = &MetricBatch{Metrics: []Metric{Count{Name: "c1"}, Count{Name: "c2"}, Count{Name: "c3"}}}
@@ -165,8 +165,8 @@ func TestSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testBatchJSON(t, [][]PayloadEntry{{split[0]}}, `[{"metrics":[{"name":"c1","type":"count","value":0}]}]`)
-	testBatchJSON(t, [][]PayloadEntry{{split[1]}}, `[{"metrics":[{"name":"c2","type":"count","value":0},{"name":"c3","type":"count","value":0}]}]`)
+	testBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"metrics":[{"name":"c1","type":"count","value":0}]}]`)
+	testBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"metrics":[{"name":"c2","type":"count","value":0},{"name":"c3","type":"count","value":0}]}]`)
 }
 
 func BenchmarkMetricsJSON(b *testing.B) {
@@ -257,7 +257,7 @@ func TestMetricAttributesJSON(t *testing.T) {
 				test.key: test.val,
 			},
 		})
-		testBatchJSON(t, [][]PayloadEntry{{batch}}, test.expect)
+		testBatchJSON(t, []PayloadBatch{{batch}}, test.expect)
 	}
 }
 
@@ -269,13 +269,13 @@ func TestCountAttributesJSON(t *testing.T) {
 		},
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 	})
-	testBatchJSON(t, [][]PayloadEntry{{batch}}, `[{"metrics":[{"name":"","type":"count","value":0,"attributes":{"zip":"zap"}}]}]`)
+	testBatchJSON(t, []PayloadBatch{{batch}}, `[{"metrics":[{"name":"","type":"count","value":0,"attributes":{"zip":"zap"}}]}]`)
 
 	batch = &MetricBatch{}
 	batch.Metrics = append(batch.Metrics, Count{
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 	})
-	testBatchJSON(t, [][]PayloadEntry{{batch}}, `[{"metrics":[{"name":"","type":"count","value":0,"attributes":{"zing":"zang"}}]}]`)
+	testBatchJSON(t, []PayloadBatch{{batch}}, `[{"metrics":[{"name":"","type":"count","value":0,"attributes":{"zing":"zang"}}]}]`)
 }
 
 func TestGaugeAttributesJSON(t *testing.T) {
@@ -289,14 +289,14 @@ func TestGaugeAttributesJSON(t *testing.T) {
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 		Timestamp:      start,
 	})
-	testBatchJSON(t, [][]PayloadEntry{{batch}}, `[{"metrics":[{"name":"","type":"gauge","value":0,"timestamp":1417136460000,"attributes":{"zip":"zap"}}]}]`)
+	testBatchJSON(t, []PayloadBatch{{batch}}, `[{"metrics":[{"name":"","type":"gauge","value":0,"timestamp":1417136460000,"attributes":{"zip":"zap"}}]}]`)
 
 	batch = &MetricBatch{}
 	batch.Metrics = append(batch.Metrics, Gauge{
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 		Timestamp:      start,
 	})
-	testBatchJSON(t, [][]PayloadEntry{{batch}}, `[{"metrics":[{"name":"","type":"gauge","value":0,"timestamp":1417136460000,"attributes":{"zing":"zang"}}]}]`)
+	testBatchJSON(t, []PayloadBatch{{batch}}, `[{"metrics":[{"name":"","type":"gauge","value":0,"timestamp":1417136460000,"attributes":{"zing":"zang"}}]}]`)
 }
 
 func TestSummaryAttributesJSON(t *testing.T) {
@@ -307,20 +307,20 @@ func TestSummaryAttributesJSON(t *testing.T) {
 		},
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 	})
-	testBatchJSON(t, [][]PayloadEntry{{batch}}, `[{"metrics":[{"name":"","type":"summary","value":{"sum":0,"count":0,"min":0,"max":0},"attributes":{"zip":"zap"}}]}]`)
+	testBatchJSON(t, []PayloadBatch{{batch}}, `[{"metrics":[{"name":"","type":"summary","value":{"sum":0,"count":0,"min":0,"max":0},"attributes":{"zip":"zap"}}]}]`)
 
 	batch = &MetricBatch{}
 	batch.Metrics = append(batch.Metrics, Summary{
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 	})
-	testBatchJSON(t, [][]PayloadEntry{{batch}}, `[{"metrics":[{"name":"","type":"summary","value":{"sum":0,"count":0,"min":0,"max":0},"attributes":{"zing":"zang"}}]}]`)
+	testBatchJSON(t, []PayloadBatch{{batch}}, `[{"metrics":[{"name":"","type":"summary","value":{"sum":0,"count":0,"min":0,"max":0},"attributes":{"zing":"zang"}}]}]`)
 }
 
 func TestBatchAttributesJSON(t *testing.T) {
 	commonAttributes := &commonAttributes{RawJSON: json.RawMessage(`{"zing":"zang"}`)}
 	commonBlock := &metricCommonBlock{Attributes: commonAttributes}
 	batch := &MetricBatch{}
-	testBatchJSON(t, [][]PayloadEntry{{commonBlock, batch}}, `[{"common":{"attributes":{"zing":"zang"}},"metrics":[]}]`)
+	testBatchJSON(t, []PayloadBatch{{commonBlock, batch}}, `[{"common":{"attributes":{"zing":"zang"}},"metrics":[]}]`)
 }
 
 func TestBatchStartEndTimesJSON(t *testing.T) {
@@ -329,23 +329,23 @@ func TestBatchStartEndTimesJSON(t *testing.T) {
 	commonBlock := &metricCommonBlock{}
 	emptyBatch := &MetricBatch{}
 
-	testBatchJSON(t, [][]PayloadEntry{{commonBlock, emptyBatch}}, `[{"common":{},"metrics":[]}]`)
+	testBatchJSON(t, []PayloadBatch{{commonBlock, emptyBatch}}, `[{"common":{},"metrics":[]}]`)
 
 	commonBlock = &metricCommonBlock{
 		Timestamp: start,
 	}
-	testBatchJSON(t, [][]PayloadEntry{{commonBlock, emptyBatch}}, `[{"common":{"timestamp":1417136460000},"metrics":[]}]`)
+	testBatchJSON(t, []PayloadBatch{{commonBlock, emptyBatch}}, `[{"common":{"timestamp":1417136460000},"metrics":[]}]`)
 
 	commonBlock = &metricCommonBlock{
 		Interval: 5 * time.Second,
 	}
-	testBatchJSON(t, [][]PayloadEntry{{commonBlock, emptyBatch}}, `[{"common":{"interval.ms":5000},"metrics":[]}]`)
+	testBatchJSON(t, []PayloadBatch{{commonBlock, emptyBatch}}, `[{"common":{"interval.ms":5000},"metrics":[]}]`)
 
 	commonBlock = &metricCommonBlock{
 		Timestamp: start,
 		Interval:  5 * time.Second,
 	}
-	testBatchJSON(t, [][]PayloadEntry{{commonBlock, emptyBatch}}, `[{"common":{"timestamp":1417136460000,"interval.ms":5000},"metrics":[]}]`)
+	testBatchJSON(t, []PayloadBatch{{commonBlock, emptyBatch}}, `[{"common":{"timestamp":1417136460000,"interval.ms":5000},"metrics":[]}]`)
 }
 
 func TestCommonAttributes(t *testing.T) {
@@ -374,7 +374,7 @@ func TestCommonAttributes(t *testing.T) {
 			Interval:   test.interval,
 			Attributes: &commonAttributes{RawJSON: test.attributesJSON},
 		}
-		testBatchJSON(t, [][]PayloadEntry{{commonBlock, emptyBatch}}, test.expect)
+		testBatchJSON(t, []PayloadBatch{{commonBlock, emptyBatch}}, test.expect)
 	}
 }
 
@@ -400,7 +400,7 @@ func TestMetricsJSONWithCommonAttributesJSON(t *testing.T) {
 			},
 		},
 	}
-	testSpanBatchJSON(t, [][]PayloadEntry{{commonBlock, batch1}, {batch2}}, `[
+	testSpanBatchJSON(t, []PayloadBatch{{commonBlock, batch1}, {batch2}}, `[
 		{
 			"common": {
 				"timestamp":1417136460000,

--- a/telemetry/metrics_batch_test.go
+++ b/telemetry/metrics_batch_test.go
@@ -400,7 +400,7 @@ func TestMetricsJSONWithCommonAttributesJSON(t *testing.T) {
 			},
 		},
 	}
-	testSpanBatchJSON(t, []Batch{{commonBlock, batch1}, {batch2}}, `[
+	testBatchJSON(t, []Batch{{commonBlock, batch1}, {batch2}}, `[
 		{
 			"common": {
 				"timestamp":1417136460000,

--- a/telemetry/metrics_batch_test.go
+++ b/telemetry/metrics_batch_test.go
@@ -427,3 +427,14 @@ func TestMetricsJSONWithCommonAttributesJSON(t *testing.T) {
 		}
 	]`)
 }
+func TestMetricBatchSplittable(t *testing.T) {
+	batch := &MetricBatch{
+		Metrics: []Metric{
+			&Summary{
+				Name:       "foo",
+				Attributes: map[string]interface{}{"zip": "zap"},
+			},
+		},
+	}
+	_ = splittablePayloadEntry(batch)
+}

--- a/telemetry/metrics_batch_test.go
+++ b/telemetry/metrics_batch_test.go
@@ -82,7 +82,7 @@ func TestMetrics(t *testing.T) {
 	}]`)
 
 	factory, _ := NewMetricRequestFactory(WithNoDefaultKey())
-	reqs, err := newRequests([]PayloadBatch{{commonBlock, metrics}}, factory)
+	reqs, err := newRequests([]Batch{{commonBlock, metrics}}, factory)
 	if err != nil {
 		t.Error("error creating request", err)
 	}
@@ -113,7 +113,7 @@ func TestMetrics(t *testing.T) {
 	}
 }
 
-func testBatchJSON(t testing.TB, batches []PayloadBatch, expect string) {
+func testBatchJSON(t testing.TB, batches []Batch, expect string) {
 	if th, ok := t.(interface{ Helper() }); ok {
 		th.Helper()
 	}
@@ -156,8 +156,8 @@ func TestSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"metrics":[{"name":"c1","type":"count","value":0}]}]`)
-	testBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"metrics":[{"name":"c2","type":"count","value":0}]}]`)
+	testBatchJSON(t, []Batch{{split[0]}}, `[{"metrics":[{"name":"c1","type":"count","value":0}]}]`)
+	testBatchJSON(t, []Batch{{split[1]}}, `[{"metrics":[{"name":"c2","type":"count","value":0}]}]`)
 
 	// test len 3
 	batch = &MetricBatch{Metrics: []Metric{Count{Name: "c1"}, Count{Name: "c2"}, Count{Name: "c3"}}}
@@ -165,8 +165,8 @@ func TestSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"metrics":[{"name":"c1","type":"count","value":0}]}]`)
-	testBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"metrics":[{"name":"c2","type":"count","value":0},{"name":"c3","type":"count","value":0}]}]`)
+	testBatchJSON(t, []Batch{{split[0]}}, `[{"metrics":[{"name":"c1","type":"count","value":0}]}]`)
+	testBatchJSON(t, []Batch{{split[1]}}, `[{"metrics":[{"name":"c2","type":"count","value":0},{"name":"c3","type":"count","value":0}]}]`)
 }
 
 func BenchmarkMetricsJSON(b *testing.B) {
@@ -206,7 +206,7 @@ func BenchmarkMetricsJSON(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	entries := []PayloadEntry{commonBlock, batch}
+	entries := []MapEntry{commonBlock, batch}
 	estimate := len(batch.Metrics) * 256
 	for i := 0; i < b.N; i++ {
 		buf := bytes.NewBuffer(make([]byte, 0, estimate))
@@ -257,7 +257,7 @@ func TestMetricAttributesJSON(t *testing.T) {
 				test.key: test.val,
 			},
 		})
-		testBatchJSON(t, []PayloadBatch{{batch}}, test.expect)
+		testBatchJSON(t, []Batch{{batch}}, test.expect)
 	}
 }
 
@@ -269,13 +269,13 @@ func TestCountAttributesJSON(t *testing.T) {
 		},
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 	})
-	testBatchJSON(t, []PayloadBatch{{batch}}, `[{"metrics":[{"name":"","type":"count","value":0,"attributes":{"zip":"zap"}}]}]`)
+	testBatchJSON(t, []Batch{{batch}}, `[{"metrics":[{"name":"","type":"count","value":0,"attributes":{"zip":"zap"}}]}]`)
 
 	batch = &MetricBatch{}
 	batch.Metrics = append(batch.Metrics, Count{
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 	})
-	testBatchJSON(t, []PayloadBatch{{batch}}, `[{"metrics":[{"name":"","type":"count","value":0,"attributes":{"zing":"zang"}}]}]`)
+	testBatchJSON(t, []Batch{{batch}}, `[{"metrics":[{"name":"","type":"count","value":0,"attributes":{"zing":"zang"}}]}]`)
 }
 
 func TestGaugeAttributesJSON(t *testing.T) {
@@ -289,14 +289,14 @@ func TestGaugeAttributesJSON(t *testing.T) {
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 		Timestamp:      start,
 	})
-	testBatchJSON(t, []PayloadBatch{{batch}}, `[{"metrics":[{"name":"","type":"gauge","value":0,"timestamp":1417136460000,"attributes":{"zip":"zap"}}]}]`)
+	testBatchJSON(t, []Batch{{batch}}, `[{"metrics":[{"name":"","type":"gauge","value":0,"timestamp":1417136460000,"attributes":{"zip":"zap"}}]}]`)
 
 	batch = &MetricBatch{}
 	batch.Metrics = append(batch.Metrics, Gauge{
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 		Timestamp:      start,
 	})
-	testBatchJSON(t, []PayloadBatch{{batch}}, `[{"metrics":[{"name":"","type":"gauge","value":0,"timestamp":1417136460000,"attributes":{"zing":"zang"}}]}]`)
+	testBatchJSON(t, []Batch{{batch}}, `[{"metrics":[{"name":"","type":"gauge","value":0,"timestamp":1417136460000,"attributes":{"zing":"zang"}}]}]`)
 }
 
 func TestSummaryAttributesJSON(t *testing.T) {
@@ -307,20 +307,20 @@ func TestSummaryAttributesJSON(t *testing.T) {
 		},
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 	})
-	testBatchJSON(t, []PayloadBatch{{batch}}, `[{"metrics":[{"name":"","type":"summary","value":{"sum":0,"count":0,"min":0,"max":0},"attributes":{"zip":"zap"}}]}]`)
+	testBatchJSON(t, []Batch{{batch}}, `[{"metrics":[{"name":"","type":"summary","value":{"sum":0,"count":0,"min":0,"max":0},"attributes":{"zip":"zap"}}]}]`)
 
 	batch = &MetricBatch{}
 	batch.Metrics = append(batch.Metrics, Summary{
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 	})
-	testBatchJSON(t, []PayloadBatch{{batch}}, `[{"metrics":[{"name":"","type":"summary","value":{"sum":0,"count":0,"min":0,"max":0},"attributes":{"zing":"zang"}}]}]`)
+	testBatchJSON(t, []Batch{{batch}}, `[{"metrics":[{"name":"","type":"summary","value":{"sum":0,"count":0,"min":0,"max":0},"attributes":{"zing":"zang"}}]}]`)
 }
 
 func TestBatchAttributesJSON(t *testing.T) {
 	commonAttributes := &commonAttributes{RawJSON: json.RawMessage(`{"zing":"zang"}`)}
 	commonBlock := &metricCommonBlock{Attributes: commonAttributes}
 	batch := &MetricBatch{}
-	testBatchJSON(t, []PayloadBatch{{commonBlock, batch}}, `[{"common":{"attributes":{"zing":"zang"}},"metrics":[]}]`)
+	testBatchJSON(t, []Batch{{commonBlock, batch}}, `[{"common":{"attributes":{"zing":"zang"}},"metrics":[]}]`)
 }
 
 func TestBatchStartEndTimesJSON(t *testing.T) {
@@ -329,23 +329,23 @@ func TestBatchStartEndTimesJSON(t *testing.T) {
 	commonBlock := &metricCommonBlock{}
 	emptyBatch := &MetricBatch{}
 
-	testBatchJSON(t, []PayloadBatch{{commonBlock, emptyBatch}}, `[{"common":{},"metrics":[]}]`)
+	testBatchJSON(t, []Batch{{commonBlock, emptyBatch}}, `[{"common":{},"metrics":[]}]`)
 
 	commonBlock = &metricCommonBlock{
 		Timestamp: start,
 	}
-	testBatchJSON(t, []PayloadBatch{{commonBlock, emptyBatch}}, `[{"common":{"timestamp":1417136460000},"metrics":[]}]`)
+	testBatchJSON(t, []Batch{{commonBlock, emptyBatch}}, `[{"common":{"timestamp":1417136460000},"metrics":[]}]`)
 
 	commonBlock = &metricCommonBlock{
 		Interval: 5 * time.Second,
 	}
-	testBatchJSON(t, []PayloadBatch{{commonBlock, emptyBatch}}, `[{"common":{"interval.ms":5000},"metrics":[]}]`)
+	testBatchJSON(t, []Batch{{commonBlock, emptyBatch}}, `[{"common":{"interval.ms":5000},"metrics":[]}]`)
 
 	commonBlock = &metricCommonBlock{
 		Timestamp: start,
 		Interval:  5 * time.Second,
 	}
-	testBatchJSON(t, []PayloadBatch{{commonBlock, emptyBatch}}, `[{"common":{"timestamp":1417136460000,"interval.ms":5000},"metrics":[]}]`)
+	testBatchJSON(t, []Batch{{commonBlock, emptyBatch}}, `[{"common":{"timestamp":1417136460000,"interval.ms":5000},"metrics":[]}]`)
 }
 
 func TestCommonAttributes(t *testing.T) {
@@ -374,7 +374,7 @@ func TestCommonAttributes(t *testing.T) {
 			Interval:   test.interval,
 			Attributes: &commonAttributes{RawJSON: test.attributesJSON},
 		}
-		testBatchJSON(t, []PayloadBatch{{commonBlock, emptyBatch}}, test.expect)
+		testBatchJSON(t, []Batch{{commonBlock, emptyBatch}}, test.expect)
 	}
 }
 
@@ -393,14 +393,14 @@ func TestMetricsJSONWithCommonAttributesJSON(t *testing.T) {
 			},
 		},
 	}
-	batch2 := &metricBatch{
+	batch2 := &MetricBatch{
 		Metrics: []Metric{
 			&Summary{
 				Name: "bar",
 			},
 		},
 	}
-	testSpanBatchJSON(t, []PayloadBatch{{commonBlock, batch1}, {batch2}}, `[
+	testSpanBatchJSON(t, []Batch{{commonBlock, batch1}, {batch2}}, `[
 		{
 			"common": {
 				"timestamp":1417136460000,

--- a/telemetry/metrics_batch_test.go
+++ b/telemetry/metrics_batch_test.go
@@ -82,7 +82,7 @@ func TestMetrics(t *testing.T) {
 	}]`)
 
 	factory, _ := NewMetricRequestFactory(WithNoDefaultKey())
-	reqs, err := newRequests([]PayloadEntry{commonBlock, metrics}, factory)
+	reqs, err := newRequests([][]PayloadEntry{{commonBlock, metrics}}, factory)
 	if err != nil {
 		t.Error("error creating request", err)
 	}
@@ -113,12 +113,12 @@ func TestMetrics(t *testing.T) {
 	}
 }
 
-func testBatchJSON(t testing.TB, entries []PayloadEntry, expect string) {
+func testBatchJSON(t testing.TB, batches [][]PayloadEntry, expect string) {
 	if th, ok := t.(interface{ Helper() }); ok {
 		th.Helper()
 	}
 	factory, _ := NewMetricRequestFactory(WithNoDefaultKey())
-	reqs, err := newRequests(entries, factory)
+	reqs, err := newRequests(batches, factory)
 	if nil != err {
 		t.Fatal(err)
 	}
@@ -156,8 +156,8 @@ func TestSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testBatchJSON(t, []PayloadEntry{split[0]}, `[{"metrics":[{"name":"c1","type":"count","value":0}]}]`)
-	testBatchJSON(t, []PayloadEntry{split[1]}, `[{"metrics":[{"name":"c2","type":"count","value":0}]}]`)
+	testBatchJSON(t, [][]PayloadEntry{{split[0]}}, `[{"metrics":[{"name":"c1","type":"count","value":0}]}]`)
+	testBatchJSON(t, [][]PayloadEntry{{split[1]}}, `[{"metrics":[{"name":"c2","type":"count","value":0}]}]`)
 
 	// test len 3
 	batch = &MetricBatch{Metrics: []Metric{Count{Name: "c1"}, Count{Name: "c2"}, Count{Name: "c3"}}}
@@ -165,8 +165,8 @@ func TestSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testBatchJSON(t, []PayloadEntry{split[0]}, `[{"metrics":[{"name":"c1","type":"count","value":0}]}]`)
-	testBatchJSON(t, []PayloadEntry{split[1]}, `[{"metrics":[{"name":"c2","type":"count","value":0},{"name":"c3","type":"count","value":0}]}]`)
+	testBatchJSON(t, [][]PayloadEntry{{split[0]}}, `[{"metrics":[{"name":"c1","type":"count","value":0}]}]`)
+	testBatchJSON(t, [][]PayloadEntry{{split[1]}}, `[{"metrics":[{"name":"c2","type":"count","value":0},{"name":"c3","type":"count","value":0}]}]`)
 }
 
 func BenchmarkMetricsJSON(b *testing.B) {
@@ -257,7 +257,7 @@ func TestMetricAttributesJSON(t *testing.T) {
 				test.key: test.val,
 			},
 		})
-		testBatchJSON(t, []PayloadEntry{batch}, test.expect)
+		testBatchJSON(t, [][]PayloadEntry{{batch}}, test.expect)
 	}
 }
 
@@ -269,13 +269,13 @@ func TestCountAttributesJSON(t *testing.T) {
 		},
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 	})
-	testBatchJSON(t, []PayloadEntry{batch}, `[{"metrics":[{"name":"","type":"count","value":0,"attributes":{"zip":"zap"}}]}]`)
+	testBatchJSON(t, [][]PayloadEntry{{batch}}, `[{"metrics":[{"name":"","type":"count","value":0,"attributes":{"zip":"zap"}}]}]`)
 
 	batch = &MetricBatch{}
 	batch.Metrics = append(batch.Metrics, Count{
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 	})
-	testBatchJSON(t, []PayloadEntry{batch}, `[{"metrics":[{"name":"","type":"count","value":0,"attributes":{"zing":"zang"}}]}]`)
+	testBatchJSON(t, [][]PayloadEntry{{batch}}, `[{"metrics":[{"name":"","type":"count","value":0,"attributes":{"zing":"zang"}}]}]`)
 }
 
 func TestGaugeAttributesJSON(t *testing.T) {
@@ -289,14 +289,14 @@ func TestGaugeAttributesJSON(t *testing.T) {
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 		Timestamp:      start,
 	})
-	testBatchJSON(t, []PayloadEntry{batch}, `[{"metrics":[{"name":"","type":"gauge","value":0,"timestamp":1417136460000,"attributes":{"zip":"zap"}}]}]`)
+	testBatchJSON(t, [][]PayloadEntry{{batch}}, `[{"metrics":[{"name":"","type":"gauge","value":0,"timestamp":1417136460000,"attributes":{"zip":"zap"}}]}]`)
 
 	batch = &MetricBatch{}
 	batch.Metrics = append(batch.Metrics, Gauge{
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 		Timestamp:      start,
 	})
-	testBatchJSON(t, []PayloadEntry{batch}, `[{"metrics":[{"name":"","type":"gauge","value":0,"timestamp":1417136460000,"attributes":{"zing":"zang"}}]}]`)
+	testBatchJSON(t, [][]PayloadEntry{{batch}}, `[{"metrics":[{"name":"","type":"gauge","value":0,"timestamp":1417136460000,"attributes":{"zing":"zang"}}]}]`)
 }
 
 func TestSummaryAttributesJSON(t *testing.T) {
@@ -307,20 +307,20 @@ func TestSummaryAttributesJSON(t *testing.T) {
 		},
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 	})
-	testBatchJSON(t, []PayloadEntry{batch}, `[{"metrics":[{"name":"","type":"summary","value":{"sum":0,"count":0,"min":0,"max":0},"attributes":{"zip":"zap"}}]}]`)
+	testBatchJSON(t, [][]PayloadEntry{{batch}}, `[{"metrics":[{"name":"","type":"summary","value":{"sum":0,"count":0,"min":0,"max":0},"attributes":{"zip":"zap"}}]}]`)
 
 	batch = &MetricBatch{}
 	batch.Metrics = append(batch.Metrics, Summary{
 		AttributesJSON: json.RawMessage(`{"zing":"zang"}`),
 	})
-	testBatchJSON(t, []PayloadEntry{batch}, `[{"metrics":[{"name":"","type":"summary","value":{"sum":0,"count":0,"min":0,"max":0},"attributes":{"zing":"zang"}}]}]`)
+	testBatchJSON(t, [][]PayloadEntry{{batch}}, `[{"metrics":[{"name":"","type":"summary","value":{"sum":0,"count":0,"min":0,"max":0},"attributes":{"zing":"zang"}}]}]`)
 }
 
 func TestBatchAttributesJSON(t *testing.T) {
 	commonAttributes := &commonAttributes{RawJSON: json.RawMessage(`{"zing":"zang"}`)}
 	commonBlock := &metricCommonBlock{Attributes: commonAttributes}
 	batch := &MetricBatch{}
-	testBatchJSON(t, []PayloadEntry{commonBlock, batch}, `[{"common":{"attributes":{"zing":"zang"}},"metrics":[]}]`)
+	testBatchJSON(t, [][]PayloadEntry{{commonBlock, batch}}, `[{"common":{"attributes":{"zing":"zang"}},"metrics":[]}]`)
 }
 
 func TestBatchStartEndTimesJSON(t *testing.T) {
@@ -329,23 +329,23 @@ func TestBatchStartEndTimesJSON(t *testing.T) {
 	commonBlock := &metricCommonBlock{}
 	emptyBatch := &MetricBatch{}
 
-	testBatchJSON(t, []PayloadEntry{commonBlock, emptyBatch}, `[{"common":{},"metrics":[]}]`)
+	testBatchJSON(t, [][]PayloadEntry{{commonBlock, emptyBatch}}, `[{"common":{},"metrics":[]}]`)
 
 	commonBlock = &metricCommonBlock{
 		Timestamp: start,
 	}
-	testBatchJSON(t, []PayloadEntry{commonBlock, emptyBatch}, `[{"common":{"timestamp":1417136460000},"metrics":[]}]`)
+	testBatchJSON(t, [][]PayloadEntry{{commonBlock, emptyBatch}}, `[{"common":{"timestamp":1417136460000},"metrics":[]}]`)
 
 	commonBlock = &metricCommonBlock{
 		Interval: 5 * time.Second,
 	}
-	testBatchJSON(t, []PayloadEntry{commonBlock, emptyBatch}, `[{"common":{"interval.ms":5000},"metrics":[]}]`)
+	testBatchJSON(t, [][]PayloadEntry{{commonBlock, emptyBatch}}, `[{"common":{"interval.ms":5000},"metrics":[]}]`)
 
 	commonBlock = &metricCommonBlock{
 		Timestamp: start,
 		Interval:  5 * time.Second,
 	}
-	testBatchJSON(t, []PayloadEntry{commonBlock, emptyBatch}, `[{"common":{"timestamp":1417136460000,"interval.ms":5000},"metrics":[]}]`)
+	testBatchJSON(t, [][]PayloadEntry{{commonBlock, emptyBatch}}, `[{"common":{"timestamp":1417136460000,"interval.ms":5000},"metrics":[]}]`)
 }
 
 func TestCommonAttributes(t *testing.T) {
@@ -374,6 +374,56 @@ func TestCommonAttributes(t *testing.T) {
 			Interval:   test.interval,
 			Attributes: &commonAttributes{RawJSON: test.attributesJSON},
 		}
-		testBatchJSON(t, []PayloadEntry{commonBlock, emptyBatch}, test.expect)
+		testBatchJSON(t, [][]PayloadEntry{{commonBlock, emptyBatch}}, test.expect)
 	}
+}
+
+func TestMetricsJSONWithCommonAttributesJSON(t *testing.T) {
+	commonBlock := &metricCommonBlock{
+		Timestamp:  time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC),
+		Interval:   5 * time.Second,
+		Attributes: &commonAttributes{RawJSON: json.RawMessage(`{"zup":"wup"}`)},
+	}
+
+	batch1 := &metricBatch{
+		Metrics: []Metric{
+			&Summary{
+				Name:       "foo",
+				Attributes: map[string]interface{}{"zip": "zap"},
+			},
+		},
+	}
+	batch2 := &metricBatch{
+		Metrics: []Metric{
+			&Summary{
+				Name: "bar",
+			},
+		},
+	}
+	testSpanBatchJSON(t, [][]PayloadEntry{{commonBlock, batch1}, {batch2}}, `[
+		{
+			"common": {
+				"timestamp":1417136460000,
+				"interval.ms":5000,
+				"attributes": {"zup":"wup"}
+			},
+			"metrics":[
+				{
+					"name":"foo",
+					"type":"summary",
+					"value":{"sum":0,"count":0,"min":0,"max":0},
+					"attributes":{"zip":"zap"}
+				}
+			]
+		},
+		{
+			"metrics":[
+				{
+					"name":"bar",
+					"type":"summary",
+					"value":{"sum":0,"count":0,"min":0,"max":0}
+				}
+			]
+		}
+	]`)
 }

--- a/telemetry/metrics_batch_test.go
+++ b/telemetry/metrics_batch_test.go
@@ -385,7 +385,7 @@ func TestMetricsJSONWithCommonAttributesJSON(t *testing.T) {
 		Attributes: &commonAttributes{RawJSON: json.RawMessage(`{"zup":"wup"}`)},
 	}
 
-	batch1 := &metricBatch{
+	batch1 := &MetricBatch{
 		Metrics: []Metric{
 			&Summary{
 				Name:       "foo",

--- a/telemetry/metrics_test.go
+++ b/telemetry/metrics_test.go
@@ -103,10 +103,7 @@ func TestVetAttributes(t *testing.T) {
 		input := map[string]interface{}{
 			key: tc.Input,
 		}
-		var errorLogged map[string]interface{}
-		output := vetAttributes(input, func(e map[string]interface{}) {
-			errorLogged = e
-		})
+		output, err := vetAttributes(input)
 		// Test the the input map has not been modified.
 		if len(input) != 1 {
 			t.Error("input map modified", input)
@@ -118,11 +115,11 @@ func TestVetAttributes(t *testing.T) {
 			if _, ok := output[key]; !ok {
 				t.Error(idx, tc.Input, output)
 			}
-			if errorLogged != nil {
+			if err != nil {
 				t.Error(idx, "unexpected error present")
 			}
 		} else {
-			if errorLogged == nil {
+			if err == nil {
 				t.Error(idx, "expected error missing")
 			}
 			if len(output) != 0 {

--- a/telemetry/request_factory.go
+++ b/telemetry/request_factory.go
@@ -18,7 +18,7 @@ const defaultScheme = "https"
 
 // PayloadEntry represents a piece of the telemetry data that is included in a single
 // request that should be sent to New Relic. Example PayloadEntry types include SpanBatch
-// and the internal spanCommonBlock.
+// and the internal SpanCommonBlock.
 type PayloadEntry interface {
 	// Type returns the type of data contained in this PayloadEntry.
 	Type() string

--- a/telemetry/request_factory.go
+++ b/telemetry/request_factory.go
@@ -16,29 +16,30 @@ import (
 const defaultUserAgent = "NewRelic-Go-TelemetrySDK/" + version
 const defaultScheme = "https"
 
-// PayloadEntry represents a piece of the telemetry data that is included in a single
-// request that should be sent to New Relic. Example PayloadEntry types include SpanBatch
+// MapEntry represents a piece of the telemetry data that is included in a single
+// request that should be sent to New Relic. Example MapEntry types include SpanBatch
 // and the internal spanCommonBlock.
-type PayloadEntry interface {
-	// Type returns the type of data contained in this PayloadEntry.
+type MapEntry interface {
+	// Type returns the type of data contained in this MapEntry.
 	Type() string
-	// Bytes returns the json serialized bytes of the PayloadEntry.
+
+	// Bytes returns the json serialized bytes of the MapEntry.
 	Bytes() []byte
 }
 
-// A PayloadBatch is an array of PayloadEntry. A single HTTP request body is composed of
-// an array of PayloadBatch.
-type PayloadBatch = []PayloadEntry
+// A Batch is an array of MapEntry. A single HTTP request body is composed of
+// an array of Batch.
+type Batch = []MapEntry
 
 // RequestFactory is used for sending telemetry data to New Relic when you want to have
 // direct access to the http.Request and you want to manually send the request using a
 // http.Client. Consider using the Harvester if you do not want to manage the requests
 // and corresponding responses manually.
 type RequestFactory interface {
-	// BuildRequest converts the telemetry payload entries into an http.Request.
+	// BuildRequest converts the telemetry payload slice into an http.Request.
 	// Do not mix telemetry data types in a single call to build request. Each
 	// telemetry data type has its own RequestFactory.
-	BuildRequest([]PayloadBatch, ...ClientOption) (*http.Request, error)
+	BuildRequest([]Batch, ...ClientOption) (*http.Request, error)
 }
 
 type requestFactory struct {
@@ -71,17 +72,17 @@ func configure(f *requestFactory, options []ClientOption) error {
 
 }
 
-func (f *hashRequestFactory) BuildRequest(batches []PayloadBatch, options ...ClientOption) (*http.Request, error) {
-	return f.buildRequest(batches, getBatchesPayloadBytes, options)
+func (f *hashRequestFactory) BuildRequest(batches []Batch, options ...ClientOption) (*http.Request, error) {
+	return f.buildRequest(batches, bufferRequestBytes, options)
 }
 
-func (f *eventRequestFactory) BuildRequest(batches []PayloadBatch, options ...ClientOption) (*http.Request, error) {
-	return f.buildRequest(batches, getEventPayloadBytes, options)
+func (f *eventRequestFactory) BuildRequest(batches []Batch, options ...ClientOption) (*http.Request, error) {
+	return f.buildRequest(batches, bufferEventRequestBytes, options)
 }
 
-type payloadWriter func(buf *bytes.Buffer, batches []PayloadBatch)
+type writer func(buf *bytes.Buffer, batches []Batch)
 
-func (f *requestFactory) buildRequest(batches []PayloadBatch, getPayloadBytes payloadWriter, options []ClientOption) (*http.Request, error) {
+func (f *requestFactory) buildRequest(batches []Batch, bufferRequestBytes writer, options []ClientOption) (*http.Request, error) {
 	configuredFactory := f
 	if len(options) > 0 {
 		configuredFactory = &requestFactory{
@@ -102,7 +103,7 @@ func (f *requestFactory) buildRequest(batches []PayloadBatch, getPayloadBytes pa
 	}
 
 	buf := &bytes.Buffer{}
-	getPayloadBytes(buf, batches)
+	bufferRequestBytes(buf, batches)
 
 	var compressedBuffer bytes.Buffer
 	zipper := configuredFactory.zippers.Get().(*gzip.Writer)
@@ -148,7 +149,7 @@ func (f *requestFactory) getHeaders() http.Header {
 	}
 }
 
-func getBatchesPayloadBytes(buf *bytes.Buffer, batches []PayloadBatch) {
+func bufferRequestBytes(buf *bytes.Buffer, batches []Batch) {
 	buf.WriteByte('[')
 	for i, batch := range batches {
 		if i > 0 {
@@ -156,23 +157,23 @@ func getBatchesPayloadBytes(buf *bytes.Buffer, batches []PayloadBatch) {
 		}
 		buf.WriteByte('{')
 		w := internal.JSONFieldsWriter{Buf: buf}
-		for _, entry := range batch {
-			w.RawField(entry.Type(), entry.Bytes())
+		for _, mapEntry := range batch {
+			w.RawField(mapEntry.Type(), mapEntry.Bytes())
 		}
 		buf.WriteByte('}')
 	}
 	buf.WriteByte(']')
 }
 
-func getEventPayloadBytes(buf *bytes.Buffer, batches []PayloadBatch) {
+func bufferEventRequestBytes(buf *bytes.Buffer, batches []Batch) {
 	buf.WriteByte('[')
 	count := 0
 	for _, batch := range batches {
-		for _, entry := range batch {
+		for _, mapEntry := range batch {
 			if count > 0 {
 				buf.WriteByte(',')
 			}
-			buf.Write(entry.Bytes())
+			buf.Write(mapEntry.Bytes())
 			count++
 		}
 	}

--- a/telemetry/request_factory.go
+++ b/telemetry/request_factory.go
@@ -18,7 +18,7 @@ const defaultScheme = "https"
 
 // PayloadEntry represents a piece of the telemetry data that is included in a single
 // request that should be sent to New Relic. Example PayloadEntry types include SpanBatch
-// and the internal SpanCommonBlock.
+// and the internal spanCommonBlock.
 type PayloadEntry interface {
 	// Type returns the type of data contained in this PayloadEntry.
 	Type() string

--- a/telemetry/request_factory_test.go
+++ b/telemetry/request_factory_test.go
@@ -71,7 +71,7 @@ func (m *MockPayloadEntry) Bytes() []byte {
 
 func TestSpanFactoryRequest(t *testing.T) {
 	f, _ := NewSpanRequestFactory(WithInsertKey("key!"))
-	request, _ := f.BuildRequest([][]PayloadEntry{{&MockPayloadEntry{}}})
+	request, _ := f.BuildRequest([]PayloadBatch{{&MockPayloadEntry{}}})
 	if request.Method != "POST" {
 		t.Error("Method was not POST")
 	}

--- a/telemetry/request_factory_test.go
+++ b/telemetry/request_factory_test.go
@@ -71,7 +71,7 @@ func (m *MockPayloadEntry) Bytes() []byte {
 
 func TestSpanFactoryRequest(t *testing.T) {
 	f, _ := NewSpanRequestFactory(WithInsertKey("key!"))
-	request, _ := f.BuildRequest([]PayloadEntry{&MockPayloadEntry{}})
+	request, _ := f.BuildRequest([][]PayloadEntry{{&MockPayloadEntry{}}})
 	if request.Method != "POST" {
 		t.Error("Method was not POST")
 	}

--- a/telemetry/request_factory_test.go
+++ b/telemetry/request_factory_test.go
@@ -71,7 +71,7 @@ func (m *MockPayloadEntry) Bytes() []byte {
 
 func TestSpanFactoryRequest(t *testing.T) {
 	f, _ := NewSpanRequestFactory(WithInsertKey("key!"))
-	request, _ := f.BuildRequest([]PayloadBatch{{&MockPayloadEntry{}}})
+	request, _ := f.BuildRequest([]Batch{{&MockPayloadEntry{}}})
 	if request.Method != "POST" {
 		t.Error("Method was not POST")
 	}

--- a/telemetry/request_test.go
+++ b/telemetry/request_test.go
@@ -51,8 +51,8 @@ func (p *testSplittablePayloadEntry) split() []splittablePayloadEntry {
 
 func TestNewRequestNoSplitNeeded(t *testing.T) {
 	testPayload := testUnsplittablePayloadEntry{rawData: json.RawMessage(`123456789`)}
-	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal([]PayloadBatch{entries}, testFactory(), func(r *http.Request) bool {
+	entries := []MapEntry{&testPayload}
+	reqs, err := newRequestsInternal([]Batch{entries}, testFactory(), func(r *http.Request) bool {
 		return false
 	})
 	if err != nil {
@@ -71,8 +71,8 @@ func TestNewRequestSplitNeeded(t *testing.T) {
 			{rawData: json.RawMessage(`"56789"`)},
 		},
 	}
-	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal([]PayloadBatch{entries}, testFactory(), func(r *http.Request) bool {
+	entries := []MapEntry{&testPayload}
+	reqs, err := newRequestsInternal([]Batch{entries}, testFactory(), func(r *http.Request) bool {
 		shouldSplit, err := payloadContains(r, "testSplittable", "123456789")
 
 		if nil != err {
@@ -100,8 +100,8 @@ func TestNewRequestSplittingMultiplePayloadsNeeded(t *testing.T) {
 			{rawData: json.RawMessage(`"56789"`)},
 		},
 	}
-	entries := []PayloadEntry{&testUnsplittablePayloadEntry, &testSplittablePayload}
-	reqs, err := newRequestsInternal([]PayloadBatch{entries}, testFactory(), func(r *http.Request) bool {
+	entries := []MapEntry{&testUnsplittablePayloadEntry, &testSplittablePayload}
+	reqs, err := newRequestsInternal([]Batch{entries}, testFactory(), func(r *http.Request) bool {
 		shouldSplit, err := payloadContains(r, "testSplittable", "123456789")
 
 		if nil != err {
@@ -141,8 +141,8 @@ func TestNewRequestCantSplitPayload(t *testing.T) {
 	testPayload := testSplittablePayloadEntry{
 		rawData: json.RawMessage(`"123456789"`),
 	}
-	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal([]PayloadBatch{entries}, testFactory(), func(r *http.Request) bool {
+	entries := []MapEntry{&testPayload}
+	reqs, err := newRequestsInternal([]Batch{entries}, testFactory(), func(r *http.Request) bool {
 		shouldSplit, err := payloadContains(r, "testSplittable", "123456789")
 
 		if nil != err {
@@ -168,8 +168,8 @@ func TestNewRequestCantSplitPayloadsEnough(t *testing.T) {
 			{rawData: json.RawMessage(`"56789"`)},
 		},
 	}
-	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal([]PayloadBatch{entries}, testFactory(), func(r *http.Request) bool {
+	entries := []MapEntry{&testPayload}
+	reqs, err := newRequestsInternal([]Batch{entries}, testFactory(), func(r *http.Request) bool {
 		isOriginalPayload, err := payloadContains(r, "testSplittable", "123456789")
 
 		if nil != err {
@@ -197,7 +197,7 @@ func TestNeedsToSplitBatchesAndEntries(t *testing.T) {
 	// Create a set of batches that must be first be split into two requests.
 	// The batch1 request must be further subdivided into two requests, creating
 	// a total of 3 requests.
-	batch1 := []PayloadEntry{
+	batch1 := []MapEntry{
 		&testSplittablePayloadEntry{
 			rawData: randomJSON(maxCompressedSizeBytes * 4),
 			splitPayloads: []*testSplittablePayloadEntry{
@@ -206,12 +206,12 @@ func TestNeedsToSplitBatchesAndEntries(t *testing.T) {
 			},
 		},
 	}
-	batch2 := []PayloadEntry{
+	batch2 := []MapEntry{
 		&testSplittablePayloadEntry{
 			rawData: randomJSON(maxCompressedSizeBytes),
 		},
 	}
-	reqs, err := newRequests([]PayloadBatch{batch1, batch2}, testFactory())
+	reqs, err := newRequests([]Batch{batch1, batch2}, testFactory())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestNeedsToSplitBatchesAndEntries(t *testing.T) {
 func TestLargeRequestNeedsSplit(t *testing.T) {
 	js := randomJSON(4 * maxCompressedSizeBytes)
 	payloadEntry := testUnsplittablePayloadEntry{rawData: js}
-	reqs, err := newRequests([]PayloadBatch{{&payloadEntry}}, testFactory())
+	reqs, err := newRequests([]Batch{{&payloadEntry}}, testFactory())
 	if reqs != nil {
 		t.Error(reqs)
 	}
@@ -235,7 +235,7 @@ func TestLargeRequestNeedsSplit(t *testing.T) {
 func TestLargeRequestNoSplit(t *testing.T) {
 	js := randomJSON(maxCompressedSizeBytes / 2)
 	payloadEntry := testUnsplittablePayloadEntry{rawData: js}
-	reqs, err := newRequests([]PayloadBatch{{&payloadEntry}}, testFactory())
+	reqs, err := newRequests([]Batch{{&payloadEntry}}, testFactory())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/telemetry/request_test.go
+++ b/telemetry/request_test.go
@@ -52,7 +52,7 @@ func (p *testSplittablePayloadEntry) split() []splittablePayloadEntry {
 func TestNewRequestNoSplitNeeded(t *testing.T) {
 	testPayload := testUnsplittablePayloadEntry{rawData: json.RawMessage(`123456789`)}
 	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal([][]PayloadEntry{entries}, testFactory(), func(r *http.Request) bool {
+	reqs, err := newRequestsInternal([]PayloadBatch{entries}, testFactory(), func(r *http.Request) bool {
 		return false
 	})
 	if err != nil {
@@ -72,7 +72,7 @@ func TestNewRequestSplitNeeded(t *testing.T) {
 		},
 	}
 	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal([][]PayloadEntry{entries}, testFactory(), func(r *http.Request) bool {
+	reqs, err := newRequestsInternal([]PayloadBatch{entries}, testFactory(), func(r *http.Request) bool {
 		shouldSplit, err := payloadContains(r, "testSplittable", "123456789")
 
 		if nil != err {
@@ -101,7 +101,7 @@ func TestNewRequestSplittingMultiplePayloadsNeeded(t *testing.T) {
 		},
 	}
 	entries := []PayloadEntry{&testUnsplittablePayloadEntry, &testSplittablePayload}
-	reqs, err := newRequestsInternal([][]PayloadEntry{entries}, testFactory(), func(r *http.Request) bool {
+	reqs, err := newRequestsInternal([]PayloadBatch{entries}, testFactory(), func(r *http.Request) bool {
 		shouldSplit, err := payloadContains(r, "testSplittable", "123456789")
 
 		if nil != err {
@@ -142,7 +142,7 @@ func TestNewRequestCantSplitPayload(t *testing.T) {
 		rawData: json.RawMessage(`"123456789"`),
 	}
 	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal([][]PayloadEntry{entries}, testFactory(), func(r *http.Request) bool {
+	reqs, err := newRequestsInternal([]PayloadBatch{entries}, testFactory(), func(r *http.Request) bool {
 		shouldSplit, err := payloadContains(r, "testSplittable", "123456789")
 
 		if nil != err {
@@ -169,7 +169,7 @@ func TestNewRequestCantSplitPayloadsEnough(t *testing.T) {
 		},
 	}
 	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal([][]PayloadEntry{entries}, testFactory(), func(r *http.Request) bool {
+	reqs, err := newRequestsInternal([]PayloadBatch{entries}, testFactory(), func(r *http.Request) bool {
 		isOriginalPayload, err := payloadContains(r, "testSplittable", "123456789")
 
 		if nil != err {
@@ -211,7 +211,7 @@ func TestNeedsToSplitBatchesAndEntries(t *testing.T) {
 			rawData: randomJSON(maxCompressedSizeBytes),
 		},
 	}
-	reqs, err := newRequests([][]PayloadEntry{batch1, batch2}, testFactory())
+	reqs, err := newRequests([]PayloadBatch{batch1, batch2}, testFactory())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestNeedsToSplitBatchesAndEntries(t *testing.T) {
 func TestLargeRequestNeedsSplit(t *testing.T) {
 	js := randomJSON(4 * maxCompressedSizeBytes)
 	payloadEntry := testUnsplittablePayloadEntry{rawData: js}
-	reqs, err := newRequests([][]PayloadEntry{{&payloadEntry}}, testFactory())
+	reqs, err := newRequests([]PayloadBatch{{&payloadEntry}}, testFactory())
 	if reqs != nil {
 		t.Error(reqs)
 	}
@@ -235,7 +235,7 @@ func TestLargeRequestNeedsSplit(t *testing.T) {
 func TestLargeRequestNoSplit(t *testing.T) {
 	js := randomJSON(maxCompressedSizeBytes / 2)
 	payloadEntry := testUnsplittablePayloadEntry{rawData: js}
-	reqs, err := newRequests([][]PayloadEntry{{&payloadEntry}}, testFactory())
+	reqs, err := newRequests([]PayloadBatch{{&payloadEntry}}, testFactory())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/telemetry/request_test.go
+++ b/telemetry/request_test.go
@@ -5,11 +5,11 @@ package telemetry
 
 import (
 	"encoding/json"
+	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"testing"
-	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
 )
 
 type testUnsplittablePayloadEntry struct {
@@ -25,7 +25,7 @@ func (p *testUnsplittablePayloadEntry) Bytes() []byte {
 }
 
 type testSplittablePayloadEntry struct {
-	rawData json.RawMessage
+	rawData       json.RawMessage
 	splitPayloads []*testSplittablePayloadEntry
 }
 
@@ -38,7 +38,7 @@ func (p *testSplittablePayloadEntry) Bytes() []byte {
 }
 
 func (p *testSplittablePayloadEntry) split() []splittablePayloadEntry {
-	if (nil == p.splitPayloads) {
+	if nil == p.splitPayloads {
 		return nil
 	}
 
@@ -52,7 +52,7 @@ func (p *testSplittablePayloadEntry) split() []splittablePayloadEntry {
 func TestNewRequestNoSplitNeeded(t *testing.T) {
 	testPayload := testUnsplittablePayloadEntry{rawData: json.RawMessage(`123456789`)}
 	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal(entries, testFactory(), func(r *http.Request) bool {
+	reqs, err := newRequestsInternal([][]PayloadEntry{entries}, testFactory(), func(r *http.Request) bool {
 		return false
 	})
 	if err != nil {
@@ -72,10 +72,10 @@ func TestNewRequestSplitNeeded(t *testing.T) {
 		},
 	}
 	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal(entries, testFactory(), func(r *http.Request) bool {
+	reqs, err := newRequestsInternal([][]PayloadEntry{entries}, testFactory(), func(r *http.Request) bool {
 		shouldSplit, err := payloadContains(r, "testSplittable", "123456789")
 
-		if (nil != err) {
+		if nil != err {
 			t.Error(err)
 		}
 
@@ -101,10 +101,10 @@ func TestNewRequestSplittingMultiplePayloadsNeeded(t *testing.T) {
 		},
 	}
 	entries := []PayloadEntry{&testUnsplittablePayloadEntry, &testSplittablePayload}
-	reqs, err := newRequestsInternal(entries, testFactory(), func(r *http.Request) bool {
+	reqs, err := newRequestsInternal([][]PayloadEntry{entries}, testFactory(), func(r *http.Request) bool {
 		shouldSplit, err := payloadContains(r, "testSplittable", "123456789")
 
-		if (nil != err) {
+		if nil != err {
 			t.Error(err)
 		}
 
@@ -120,18 +120,18 @@ func TestNewRequestSplittingMultiplePayloadsNeeded(t *testing.T) {
 	expectedSplitPayloads := []string{"1234", "56789"}
 	for i := 0; i < 2; i++ {
 		hasUnsplittablePayload, err := payloadContains(reqs[i], "testUnsplittable", "abc")
-		if (err != nil) {
+		if err != nil {
 			t.Error(err)
 		}
-		if (!hasUnsplittablePayload) {
+		if !hasUnsplittablePayload {
 			t.Error("Each request should contain the unsplittable payload")
 		}
 
 		hasSplittablePayload, err := payloadContains(reqs[i], "testSplittable", expectedSplitPayloads[i])
-		if (err != nil) {
+		if err != nil {
 			t.Error(err)
 		}
-		if (!hasSplittablePayload) {
+		if !hasSplittablePayload {
 			t.Errorf("testSplittable did not contain %q", expectedSplitPayloads[i])
 		}
 	}
@@ -142,10 +142,10 @@ func TestNewRequestCantSplitPayload(t *testing.T) {
 		rawData: json.RawMessage(`"123456789"`),
 	}
 	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal(entries, testFactory(), func(r *http.Request) bool {
+	reqs, err := newRequestsInternal([][]PayloadEntry{entries}, testFactory(), func(r *http.Request) bool {
 		shouldSplit, err := payloadContains(r, "testSplittable", "123456789")
 
-		if (nil != err) {
+		if nil != err {
 			t.Error(err)
 		}
 
@@ -169,16 +169,16 @@ func TestNewRequestCantSplitPayloadsEnough(t *testing.T) {
 		},
 	}
 	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal(entries, testFactory(), func(r *http.Request) bool {
+	reqs, err := newRequestsInternal([][]PayloadEntry{entries}, testFactory(), func(r *http.Request) bool {
 		isOriginalPayload, err := payloadContains(r, "testSplittable", "123456789")
 
-		if (nil != err) {
+		if nil != err {
 			t.Error(err)
 		}
 
 		isPayloadThatCantBeSplitAgain, err := payloadContains(r, "testSplittable", "56789")
 
-		if (nil != err) {
+		if nil != err {
 			t.Error(err)
 		}
 
@@ -193,10 +193,37 @@ func TestNewRequestCantSplitPayloadsEnough(t *testing.T) {
 	}
 }
 
+func TestNeedsToSplitBatchesAndEntries(t *testing.T) {
+	// Create a set of batches that must be first be split into two requests.
+	// The batch1 request must be further subdivided into two requests, creating
+	// a total of 3 requests.
+	batch1 := []PayloadEntry{
+		&testSplittablePayloadEntry{
+			rawData: randomJSON(maxCompressedSizeBytes * 4),
+			splitPayloads: []*testSplittablePayloadEntry{
+				{rawData: randomJSON(maxCompressedSizeBytes * 2)},
+				{rawData: randomJSON(maxCompressedSizeBytes * 2)},
+			},
+		},
+	}
+	batch2 := []PayloadEntry{
+		&testSplittablePayloadEntry{
+			rawData: randomJSON(maxCompressedSizeBytes),
+		},
+	}
+	reqs, err := newRequests([][]PayloadEntry{batch1, batch2}, testFactory())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reqs) != 3 {
+		t.Fatal(len(reqs))
+	}
+}
+
 func TestLargeRequestNeedsSplit(t *testing.T) {
 	js := randomJSON(4 * maxCompressedSizeBytes)
 	payloadEntry := testUnsplittablePayloadEntry{rawData: js}
-	reqs, err := newRequests([]PayloadEntry{&payloadEntry}, testFactory())
+	reqs, err := newRequests([][]PayloadEntry{{&payloadEntry}}, testFactory())
 	if reqs != nil {
 		t.Error(reqs)
 	}
@@ -208,7 +235,7 @@ func TestLargeRequestNeedsSplit(t *testing.T) {
 func TestLargeRequestNoSplit(t *testing.T) {
 	js := randomJSON(maxCompressedSizeBytes / 2)
 	payloadEntry := testUnsplittablePayloadEntry{rawData: js}
-	reqs, err := newRequests([]PayloadEntry{&payloadEntry}, testFactory())
+	reqs, err := newRequests([][]PayloadEntry{{&payloadEntry}}, testFactory())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +267,7 @@ func randomJSON(numBytes int) json.RawMessage {
 	return js
 }
 
-func testFactory() (RequestFactory) {
+func testFactory() RequestFactory {
 	factory, _ := NewMetricRequestFactory(WithNoDefaultKey())
 	return factory
 }

--- a/telemetry/spans.go
+++ b/telemetry/spans.go
@@ -172,10 +172,10 @@ func (batch *SpanBatch) Bytes() []byte {
 	return buf.Bytes()
 }
 
-func (batch *SpanBatch) split() []*SpanBatch {
+func (batch *SpanBatch) split() []splittablePayloadEntry {
 	if len(batch.Spans) < 2 {
 		return nil
 	}
 	middle := len(batch.Spans) / 2
-	return []*SpanBatch{{Spans: batch.Spans[0:middle]}, {Spans: batch.Spans[middle:]}}
+	return []splittablePayloadEntry{&SpanBatch{Spans: batch.Spans[0:middle]}, &SpanBatch{Spans: batch.Spans[middle:]}}
 }

--- a/telemetry/spans.go
+++ b/telemetry/spans.go
@@ -105,12 +105,12 @@ type spanCommonBlock struct {
 	Attributes *commonAttributes
 }
 
-// Type returns the type of data contained in this PayloadEntry.
+// Type returns the type of data contained in this MapEntry.
 func (c *spanCommonBlock) Type() string {
 	return "common"
 }
 
-// Bytes returns the json serialized bytes of the PayloadEntry.
+// Bytes returns the json serialized bytes of the MapEntry.
 func (c *spanCommonBlock) Bytes() []byte {
 	buf := &bytes.Buffer{}
 	buf.WriteByte('{')
@@ -120,7 +120,7 @@ func (c *spanCommonBlock) Bytes() []byte {
 	return buf.Bytes()
 }
 
-// SpanCommonBlockBuilder is a builder for the span common block PayloadEntry.
+// SpanCommonBlockBuilder is a builder for the span common block MapEntry.
 type SpanCommonBlockBuilder struct {
 	commonAttributes map[string]interface{}
 }
@@ -131,10 +131,10 @@ func (b *SpanCommonBlockBuilder) WithAttributes(commonAttributes map[string]inte
 	return b
 }
 
-// Build creates a span common block PayloadEntry from the builder. If invalid
+// Build creates a span common block MapEntry from the builder. If invalid
 // attributes are detected, the response will contain the valid attributes and an
 // error describing which keys were invalid.
-func (b *SpanCommonBlockBuilder) Build() (PayloadEntry, error) {
+func (b *SpanCommonBlockBuilder) Build() (MapEntry, error) {
 	scb := spanCommonBlock{}
 	if b.commonAttributes != nil {
 		validCommonAttrs, err := newCommonAttributes(b.commonAttributes)
@@ -149,12 +149,12 @@ type SpanBatch struct {
 	Spans []Span
 }
 
-// Type returns the type of data contained in this PayloadEntry.
+// Type returns the type of data contained in this MapEntry.
 func (batch *SpanBatch) Type() string {
 	return spanTypeName
 }
 
-// Bytes returns the json serialized bytes of the PayloadEntry.
+// Bytes returns the json serialized bytes of the MapEntry.
 func (batch *SpanBatch) Bytes() []byte {
 	buf := &bytes.Buffer{}
 	buf.WriteByte('[')

--- a/telemetry/spans.go
+++ b/telemetry/spans.go
@@ -102,7 +102,7 @@ func (s *Span) writeJSON(buf *bytes.Buffer) {
 
 // spanCommonBlock represents the shared elements of a SpanBatch.
 type spanCommonBlock struct {
-	Attributes *commonAttributes
+	attributes *commonAttributes
 }
 
 // Type returns the type of data contained in this MapEntry.
@@ -115,7 +115,9 @@ func (c *spanCommonBlock) Bytes() []byte {
 	buf := &bytes.Buffer{}
 	buf.WriteByte('{')
 	w := internal.JSONFieldsWriter{Buf: buf}
-	w.RawField(c.Attributes.Type(), c.Attributes.Bytes())
+	if c.attributes != nil {
+		w.RawField(c.attributes.Type(), c.attributes.Bytes())
+	}
 	buf.WriteByte('}')
 	return buf.Bytes()
 }
@@ -135,18 +137,13 @@ func NewSpanCommonBlock(options ...SpanCommonBlockOption) (MapEntry, error) {
 	return scb, nil
 }
 
-// SpanCommonBlockBuilder is a builder for the span common block MapEntry.
-type SpanCommonBlockBuilder struct {
-	commonAttributes map[string]interface{}
-}
-
 // WithSpanAttributes creates a SpanCommonBlockOption to specify the common attributes of the common block.
 // If invalid attributes are detected an error will be returned describing which keys were invalid, but
 // the valid attributes will still be added to the span common block.
 func WithSpanAttributes(commonAttributes map[string]interface{}) SpanCommonBlockOption {
 	return func(scb *spanCommonBlock) error {
 		validCommonAttr, err := newCommonAttributes(commonAttributes)
-		scb.Attributes = validCommonAttr
+		scb.attributes = validCommonAttr
 		return err
 	}
 }

--- a/telemetry/spans.go
+++ b/telemetry/spans.go
@@ -100,23 +100,48 @@ func (s *Span) writeJSON(buf *bytes.Buffer) {
 	buf.WriteByte('}')
 }
 
-type spanCommonBlock struct {
+// SpanCommonBlock represents the shared elements of a SpanBatch.
+type SpanCommonBlock struct {
 	Attributes *commonAttributes
 }
 
 // Type returns the type of data contained in this PayloadEntry.
-func (c *spanCommonBlock) Type() string {
+func (c *SpanCommonBlock) Type() string {
 	return "common"
 }
 
 // Bytes returns the json serialized bytes of the PayloadEntry.
-func (c *spanCommonBlock) Bytes() []byte {
+func (c *SpanCommonBlock) Bytes() []byte {
 	buf := &bytes.Buffer{}
 	buf.WriteByte('{')
 	w := internal.JSONFieldsWriter{Buf: buf}
 	w.RawField(c.Attributes.Type(), c.Attributes.Bytes())
 	buf.WriteByte('}')
 	return buf.Bytes()
+}
+
+// SpanCommonBlockBuilder is a builder for SpanCommonBlock.
+type SpanCommonBlockBuilder struct {
+	commonAttributes map[string]interface{}
+}
+
+// WithAttributes sets the common attributes for the builder.
+func (b *SpanCommonBlockBuilder) WithAttributes(commonAttributes map[string]interface{}) *SpanCommonBlockBuilder {
+	b.commonAttributes = commonAttributes
+	return b
+}
+
+// Build creates a SpanCommonBlock from the builder.
+func (b *SpanCommonBlockBuilder) Build() (*SpanCommonBlock, error) {
+	scb := SpanCommonBlock{}
+	if b.commonAttributes != nil {
+		attrs, err := newCommonAttributes(b.commonAttributes)
+		if err != nil {
+			return nil, err
+		}
+		scb.Attributes = attrs
+	}
+	return &scb, nil
 }
 
 // SpanBatch represents a single batch of spans to report to New Relic.

--- a/telemetry/spans.go
+++ b/telemetry/spans.go
@@ -114,8 +114,8 @@ func (c *spanCommonBlock) Type() string {
 func (c *spanCommonBlock) Bytes() []byte {
 	buf := &bytes.Buffer{}
 	buf.WriteByte('{')
-	w := internal.JSONFieldsWriter{Buf: buf}
 	if c.attributes != nil {
+		w := internal.JSONFieldsWriter{Buf: buf}
 		w.RawField(c.attributes.Type(), c.attributes.Bytes())
 	}
 	buf.WriteByte('}')

--- a/telemetry/spans.go
+++ b/telemetry/spans.go
@@ -100,18 +100,18 @@ func (s *Span) writeJSON(buf *bytes.Buffer) {
 	buf.WriteByte('}')
 }
 
-// SpanCommonBlock represents the shared elements of a SpanBatch.
-type SpanCommonBlock struct {
+// spanCommonBlock represents the shared elements of a SpanBatch.
+type spanCommonBlock struct {
 	Attributes *commonAttributes
 }
 
 // Type returns the type of data contained in this PayloadEntry.
-func (c *SpanCommonBlock) Type() string {
+func (c *spanCommonBlock) Type() string {
 	return "common"
 }
 
 // Bytes returns the json serialized bytes of the PayloadEntry.
-func (c *SpanCommonBlock) Bytes() []byte {
+func (c *spanCommonBlock) Bytes() []byte {
 	buf := &bytes.Buffer{}
 	buf.WriteByte('{')
 	w := internal.JSONFieldsWriter{Buf: buf}
@@ -120,7 +120,7 @@ func (c *SpanCommonBlock) Bytes() []byte {
 	return buf.Bytes()
 }
 
-// SpanCommonBlockBuilder is a builder for SpanCommonBlock.
+// SpanCommonBlockBuilder is a builder for the span common block PayloadEntry.
 type SpanCommonBlockBuilder struct {
 	commonAttributes map[string]interface{}
 }
@@ -131,15 +131,15 @@ func (b *SpanCommonBlockBuilder) WithAttributes(commonAttributes map[string]inte
 	return b
 }
 
-// Build creates a SpanCommonBlock from the builder.
-func (b *SpanCommonBlockBuilder) Build() (*SpanCommonBlock, error) {
-	scb := SpanCommonBlock{}
+// Build creates a span common block PayloadEntry from the builder. If invalid
+// attributes are detected, the response will contain the valid attributes and an
+// error describing which keys were invalid.
+func (b *SpanCommonBlockBuilder) Build() (PayloadEntry, error) {
+	scb := spanCommonBlock{}
 	if b.commonAttributes != nil {
-		attrs, err := newCommonAttributes(b.commonAttributes)
-		if err != nil {
-			return nil, err
-		}
-		scb.Attributes = attrs
+		validCommonAttrs, err := newCommonAttributes(b.commonAttributes)
+		scb.Attributes = validCommonAttrs
+		return &scb, err
 	}
 	return &scb, nil
 }

--- a/telemetry/spans_batch_test.go
+++ b/telemetry/spans_batch_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
 )
 
-func testSpanBatchJSON(t testing.TB, batches []PayloadBatch, expect string) {
+func testSpanBatchJSON(t testing.TB, batches []Batch, expect string) {
 	if th, ok := t.(interface{ Helper() }); ok {
 		th.Helper()
 	}
@@ -68,8 +68,8 @@ func TestSpansPayloadSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testSpanBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"a"}}]}]`)
-	testSpanBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"b"}}]}]`)
+	testSpanBatchJSON(t, []Batch{{split[0]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"a"}}]}]`)
+	testSpanBatchJSON(t, []Batch{{split[1]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"b"}}]}]`)
 
 	// test len 3
 	sp = &SpanBatch{Spans: []Span{{Name: "a"}, {Name: "b"}, {Name: "c"}}}
@@ -77,8 +77,8 @@ func TestSpansPayloadSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testSpanBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"a"}}]}]`)
-	testSpanBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"b"}},{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"c"}}]}]`)
+	testSpanBatchJSON(t, []Batch{{split[0]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"a"}}]}]`)
+	testSpanBatchJSON(t, []Batch{{split[1]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"b"}},{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"c"}}]}]`)
 }
 
 func TestSpansJSON(t *testing.T) {
@@ -95,7 +95,7 @@ func TestSpansJSON(t *testing.T) {
 			Attributes:  map[string]interface{}{"zip": "zap"},
 		},
 	}}
-	testSpanBatchJSON(t, []PayloadBatch{{batch}}, `[{"spans":[
+	testSpanBatchJSON(t, []Batch{{batch}}, `[{"spans":[
 		{
 			"id":"",
 			"trace.id":"",
@@ -146,7 +146,7 @@ func TestSpansJSONWithCommonAttributesJSON(t *testing.T) {
 			},
 		},
 	}
-	testSpanBatchJSON(t, []PayloadBatch{{commonBlock, batch1}, {batch2}}, `[
+	testSpanBatchJSON(t, []Batch{{commonBlock, batch1}, {batch2}}, `[
 		{
 			"common": {
 				"attributes": {

--- a/telemetry/spans_batch_test.go
+++ b/telemetry/spans_batch_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
 )
 
-func testSpanBatchJSON(t testing.TB, entries []PayloadEntry, expect string) {
+func testSpanBatchJSON(t testing.TB, batches [][]PayloadEntry, expect string) {
 	if th, ok := t.(interface{ Helper() }); ok {
 		th.Helper()
 	}
 	factory, _ := NewSpanRequestFactory(WithNoDefaultKey())
-	reqs, err := newRequests(entries, factory)
+	reqs, err := newRequests(batches, factory)
 	if nil != err {
 		t.Fatal(err)
 	}
@@ -31,8 +31,7 @@ func testSpanBatchJSON(t testing.TB, entries []PayloadEntry, expect string) {
 	if err != nil {
 		t.Fatal("unable to uncompress body", err)
 	}
-	js := string(uncompressedBytes)
-	actual := string(js)
+	actual := string(uncompressedBytes)
 	compact := compactJSONString(expect)
 	if actual != compact {
 		t.Errorf("\nexpect=%s\nactual=%s\n", compact, actual)
@@ -70,8 +69,8 @@ func TestSpansPayloadSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testSpanBatchJSON(t, []PayloadEntry { split[0] }, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"a"}}]}]`)
-	testSpanBatchJSON(t, []PayloadEntry { split[1] }, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"b"}}]}]`)
+	testSpanBatchJSON(t, [][]PayloadEntry{{split[0]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"a"}}]}]`)
+	testSpanBatchJSON(t, [][]PayloadEntry{{split[1]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"b"}}]}]`)
 
 	// test len 3
 	sp = &SpanBatch{Spans: []Span{{Name: "a"}, {Name: "b"}, {Name: "c"}}}
@@ -79,8 +78,8 @@ func TestSpansPayloadSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testSpanBatchJSON(t, []PayloadEntry { split[0] }, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"a"}}]}]`)
-	testSpanBatchJSON(t, []PayloadEntry { split[1] }, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"b"}},{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"c"}}]}]`)
+	testSpanBatchJSON(t, [][]PayloadEntry{{split[0]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"a"}}]}]`)
+	testSpanBatchJSON(t, [][]PayloadEntry{{split[1]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"b"}},{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"c"}}]}]`)
 }
 
 func TestSpansJSON(t *testing.T) {
@@ -97,7 +96,7 @@ func TestSpansJSON(t *testing.T) {
 			Attributes:  map[string]interface{}{"zip": "zap"},
 		},
 	}}
-	testSpanBatchJSON(t, []PayloadEntry { batch }, `[{"spans":[
+	testSpanBatchJSON(t, [][]PayloadEntry{{batch}}, `[{"spans":[
 		{
 			"id":"",
 			"trace.id":"",
@@ -121,15 +120,15 @@ func TestSpansJSON(t *testing.T) {
 }
 
 func TestSpansJSONWithCommonAttributesJSON(t *testing.T) {
-	commonBlock := &spanCommonBlock {
-		Attributes: &commonAttributes { RawJSON: json.RawMessage(`{"zup":"wup"}`) },
+	commonBlock := &spanCommonBlock{
+		Attributes: &commonAttributes{RawJSON: json.RawMessage(`{"zup":"wup"}`)},
 	}
 
-	batch := &SpanBatch{
+	batch1 := &SpanBatch{
 		Spans: []Span{
 			{
-				ID:          "myid",
-				TraceID:     "mytraceid",
+				ID:          "myid1",
+				TraceID:     "mytraceid1",
 				Name:        "myname",
 				ParentID:    "myparentid",
 				Timestamp:   time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC),
@@ -138,18 +137,46 @@ func TestSpansJSONWithCommonAttributesJSON(t *testing.T) {
 				Attributes:  map[string]interface{}{"zip": "zap"},
 			},
 		}}
-	testSpanBatchJSON(t, []PayloadEntry {commonBlock, batch}, `[{"common":{"attributes":{"zup":"wup"}},"spans":[
+	batch2 := &SpanBatch{
+		Spans: []Span{
+			{
+				ID:        "myid2",
+				TraceID:   "mytraceid2",
+				Timestamp: time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC),
+			},
+		},
+	}
+	testSpanBatchJSON(t, [][]PayloadEntry{{commonBlock, batch1}, {batch2}}, `[
 		{
-			"id":"myid",
-			"trace.id":"mytraceid",
-			"timestamp":1417136460000,
-			"attributes": {
-				"name":"myname",
-				"parent.id":"myparentid",
-				"duration.ms":2000,
-				"service.name":"myentity",
-				"zip":"zap"
-			}
+			"common": {
+				"attributes": {
+					"zup":"wup"
+				}
+			},
+			"spans":[
+				{
+					"id":"myid1",
+					"trace.id":"mytraceid1",
+					"timestamp":1417136460000,
+					"attributes": {
+						"name":"myname",
+						"parent.id":"myparentid",
+						"duration.ms":2000,
+						"service.name":"myentity",
+						"zip":"zap"
+					}
+				}
+			]
+		},
+		{
+			"spans":[
+				{
+					"id":"myid2",
+					"trace.id":"mytraceid2",
+					"timestamp":1417136460000,
+					"attributes": {}
+				}
+			]
 		}
-	]}]`)
+	]`)
 }

--- a/telemetry/spans_batch_test.go
+++ b/telemetry/spans_batch_test.go
@@ -180,3 +180,16 @@ func TestSpansJSONWithCommonAttributesJSON(t *testing.T) {
 		}
 	]`)
 }
+
+func TestSpanBatchSplittable(t *testing.T) {
+	batch := &SpanBatch{
+		Spans: []Span{
+			{
+				ID:        "myid2",
+				TraceID:   "mytraceid2",
+				Timestamp: time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC),
+			},
+		},
+	}
+	_ = splittablePayloadEntry(batch)
+}

--- a/telemetry/spans_batch_test.go
+++ b/telemetry/spans_batch_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
 )
 
-func testSpanBatchJSON(t testing.TB, batches [][]PayloadEntry, expect string) {
+func testSpanBatchJSON(t testing.TB, batches []PayloadBatch, expect string) {
 	if th, ok := t.(interface{ Helper() }); ok {
 		th.Helper()
 	}
@@ -68,8 +68,8 @@ func TestSpansPayloadSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testSpanBatchJSON(t, [][]PayloadEntry{{split[0]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"a"}}]}]`)
-	testSpanBatchJSON(t, [][]PayloadEntry{{split[1]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"b"}}]}]`)
+	testSpanBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"a"}}]}]`)
+	testSpanBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"b"}}]}]`)
 
 	// test len 3
 	sp = &SpanBatch{Spans: []Span{{Name: "a"}, {Name: "b"}, {Name: "c"}}}
@@ -77,8 +77,8 @@ func TestSpansPayloadSplit(t *testing.T) {
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testSpanBatchJSON(t, [][]PayloadEntry{{split[0]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"a"}}]}]`)
-	testSpanBatchJSON(t, [][]PayloadEntry{{split[1]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"b"}},{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"c"}}]}]`)
+	testSpanBatchJSON(t, []PayloadBatch{{split[0]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"a"}}]}]`)
+	testSpanBatchJSON(t, []PayloadBatch{{split[1]}}, `[{"spans":[{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"b"}},{"id":"","trace.id":"","timestamp":-6795364578871,"attributes":{"name":"c"}}]}]`)
 }
 
 func TestSpansJSON(t *testing.T) {
@@ -95,7 +95,7 @@ func TestSpansJSON(t *testing.T) {
 			Attributes:  map[string]interface{}{"zip": "zap"},
 		},
 	}}
-	testSpanBatchJSON(t, [][]PayloadEntry{{batch}}, `[{"spans":[
+	testSpanBatchJSON(t, []PayloadBatch{{batch}}, `[{"spans":[
 		{
 			"id":"",
 			"trace.id":"",
@@ -146,7 +146,7 @@ func TestSpansJSONWithCommonAttributesJSON(t *testing.T) {
 			},
 		},
 	}
-	testSpanBatchJSON(t, [][]PayloadEntry{{commonBlock, batch1}, {batch2}}, `[
+	testSpanBatchJSON(t, []PayloadBatch{{commonBlock, batch1}, {batch2}}, `[
 		{
 			"common": {
 				"attributes": {

--- a/telemetry/spans_batch_test.go
+++ b/telemetry/spans_batch_test.go
@@ -4,7 +4,6 @@
 package telemetry
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -120,8 +119,9 @@ func TestSpansJSON(t *testing.T) {
 }
 
 func TestSpansJSONWithCommonAttributesJSON(t *testing.T) {
-	commonBlock := &spanCommonBlock{
-		Attributes: &commonAttributes{RawJSON: json.RawMessage(`{"zup":"wup"}`)},
+	commonBlock, err := (&SpanCommonBlockBuilder{}).WithAttributes(map[string]interface{}{"zup": "wup"}).Build()
+	if err != nil {
+		t.Fail()
 	}
 
 	batch1 := &SpanBatch{

--- a/telemetry/spans_batch_test.go
+++ b/telemetry/spans_batch_test.go
@@ -119,7 +119,7 @@ func TestSpansJSON(t *testing.T) {
 }
 
 func TestSpansJSONWithCommonAttributesJSON(t *testing.T) {
-	commonBlock, err := (&SpanCommonBlockBuilder{}).WithAttributes(map[string]interface{}{"zup": "wup"}).Build()
+	commonBlock, err := NewSpanCommonBlock(WithSpanAttributes(map[string]interface{}{"zup": "wup"}))
 	if err != nil {
 		t.Fail()
 	}

--- a/telemetry/spans_test.go
+++ b/telemetry/spans_test.go
@@ -149,6 +149,37 @@ func TestRecordSpanNilHarvester(t *testing.T) {
 	}
 }
 
+func TestSpanCommonBlock(t *testing.T) {
+	type testCase struct {
+		expected string
+		options []SpanCommonBlockOption
+	}
+	tests := []testCase{
+		{
+			expected: `{}`,
+			options: nil,
+		},
+		{
+			expected: `{"attributes":null}`,
+			options: []SpanCommonBlockOption{WithSpanAttributes(nil)},
+		},
+		{
+			expected: `{"attributes":{"zup":"wup"}}`,
+			options: []SpanCommonBlockOption{WithSpanAttributes(map[string]interface{}{"zup": "wup"})},
+		},
+	}
+	for _, test := range tests {
+		mapEntry, err := NewSpanCommonBlock(test.options...)
+		if err != nil {
+			t.Fail()
+		}
+		json := string(mapEntry.Bytes())
+		if test.expected != json {
+			t.Errorf("Expected spanCommonBlock to serialize to %s but was %s", test.expected, json)
+		}
+	}
+}
+
 func TestSpanWithEvents(t *testing.T) {
 	tm := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
 	h, _ := NewHarvester(configTesting)

--- a/telemetry/spans_test.go
+++ b/telemetry/spans_test.go
@@ -19,13 +19,13 @@ func BenchmarkSpansJSON(b *testing.B) {
 
 	for i := 0; i < numSpans; i++ {
 		batch.Spans = append(batch.Spans, Span{
-			ID:             "myid",
-			TraceID:        "mytraceid",
-			Name:           "myname",
-			ParentID:       "myparent",
-			Timestamp:      tm,
-			Duration:       2 * time.Second,
-			ServiceName:    "myentity",
+			ID:          "myid",
+			TraceID:     "mytraceid",
+			Name:        "myname",
+			ParentID:    "myparent",
+			Timestamp:   tm,
+			Duration:    2 * time.Second,
+			ServiceName: "myentity",
 		})
 	}
 


### PR DESCRIPTION
- Update `RequestFactory` to accept batches of payload entries `BuildRequest([][]PayloadEntry, ...ClientOption) (*http.Request, error)`
- Export `SpanCommonBlock` and add a `SpanCommonBlockBuilder` for constructing. 

Open questions:
1. Should we improve the clarity of `BuildRequest(...)` by adding a type to represent a batch of payload entries? So:
```
type PayloadBatch {
 PayloadEntries []PayloadEntry
}
...
BuildRequest([]PayloadBatch, ...ClientOption) (*http.Request, error)
```
2. Should we have builders for each fo the common blocks? Or should we just export them and their component types (i.e. `commonAttributes` would need to be exported without offering a builder)?