### PR TITLE
Convert to stack based request building.

### DIFF
--- a/telemetry/harvester.go
+++ b/telemetry/harvester.go
@@ -295,7 +295,7 @@ func postData(req *http.Request, client *http.Client) response {
 	return r
 }
 
-func (h *Harvester) swapOutMetrics(now time.Time) []*http.Request {
+func (h *Harvester) swapOutMetrics(now time.Time) []http.Request {
 	h.lock.Lock()
 	lastHarvest := h.lastHarvest
 	h.lastHarvest = now
@@ -339,7 +339,7 @@ func (h *Harvester) swapOutMetrics(now time.Time) []*http.Request {
 	return reqs
 }
 
-func (h *Harvester) swapOutSpans() []*http.Request {
+func (h *Harvester) swapOutSpans() []http.Request {
 	h.lock.Lock()
 	sps := h.spans
 	h.spans = nil
@@ -365,7 +365,7 @@ func (h *Harvester) swapOutSpans() []*http.Request {
 	return reqs
 }
 
-func (h *Harvester) swapOutEvents() []*http.Request {
+func (h *Harvester) swapOutEvents() []http.Request {
 	h.lock.Lock()
 	events := h.events
 	h.events = nil
@@ -389,7 +389,7 @@ func (h *Harvester) swapOutEvents() []*http.Request {
 	return reqs
 }
 
-func (h *Harvester) swapOutLogs() []*http.Request {
+func (h *Harvester) swapOutLogs() []http.Request {
 	h.lock.Lock()
 	logs := h.logs
 	h.logs = nil
@@ -483,7 +483,7 @@ func (h *Harvester) HarvestNow(ct context.Context) {
 	ctx, cancel := context.WithTimeout(ct, h.config.HarvestTimeout)
 	defer cancel()
 
-	var reqs []*http.Request
+	var reqs []http.Request
 	reqs = append(reqs, h.swapOutMetrics(time.Now())...)
 	reqs = append(reqs, h.swapOutSpans()...)
 	reqs = append(reqs, h.swapOutEvents()...)

--- a/telemetry/harvester_test.go
+++ b/telemetry/harvester_test.go
@@ -114,16 +114,16 @@ func TestPathNotUsedFromUrls(t *testing.T) {
 	validateReqUsedCorrectEndpointValues(eventReqs, "http://test.events.newrelic.com:8003/v1/accounts/events", "test.events.newrelic.com:8003", t)
 }
 
-func validateReqUsedCorrectEndpointValues(reqs []*http.Request, expectedURL string, expectedEndpoint string, t *testing.T) {
-	if (len(reqs) < 1) {
+func validateReqUsedCorrectEndpointValues(reqs []http.Request, expectedURL string, expectedEndpoint string, t *testing.T) {
+	if len(reqs) < 1 {
 		t.Error("Expected at least 1 requst to validate")
 	}
 
 	for _, req := range reqs {
-		if (req.Host != expectedEndpoint) {
+		if req.Host != expectedEndpoint {
 			t.Errorf("Got req.Host %v but expected %v", req.Host, expectedEndpoint)
 		}
-		if (req.URL.String() != expectedURL) {
+		if req.URL.String() != expectedURL {
 			t.Errorf("Got req.URL %v but expected %v", req.URL.String(), expectedURL)
 		}
 	}

--- a/telemetry/request.go
+++ b/telemetry/request.go
@@ -21,25 +21,25 @@ var (
 	errUnableToSplit = fmt.Errorf("unable to split large payload further")
 )
 
-func requestNeedsSplit(r *http.Request) bool {
+func requestNeedsSplit(r http.Request) bool {
 	return r.ContentLength >= maxCompressedSizeBytes
 }
 
-func newRequests(entries []PayloadEntry, factory RequestFactory) ([]*http.Request, error) {
+func newRequests(entries []PayloadEntry, factory RequestFactory) ([]http.Request, error) {
 	return newRequestsInternal(entries, factory, requestNeedsSplit)
 }
 
-func newRequestsInternal(entries []PayloadEntry, factory RequestFactory, needsSplit func(*http.Request) bool) ([]*http.Request, error) {
+func newRequestsInternal(entries []PayloadEntry, factory RequestFactory, needsSplit func(http.Request) bool) ([]http.Request, error) {
 	r, err := factory.BuildRequest(entries)
-	if (nil != err) {
+	if nil != err {
 		return nil, err
 	}
 
 	if !needsSplit(r) {
-		return []*http.Request{r}, nil
+		return []http.Request{r}, nil
 	}
 
-	var reqs []*http.Request
+	var reqs []http.Request
 	var splitPayload1 []PayloadEntry
 	var splitPayload2 []PayloadEntry
 	payloadWasSplit := false

--- a/telemetry/request_factory.go
+++ b/telemetry/request_factory.go
@@ -34,7 +34,7 @@ type RequestFactory interface {
 	// BuildRequest converts the telemetry payload entries into an http.Request.
 	// Do not mix telemetry data types in a single call to build request. Each
 	// telemetry data type has its own RequestFactory.
-	BuildRequest([]PayloadEntry, ...ClientOption) (*http.Request, error)
+	BuildRequest([]PayloadEntry, ...ClientOption) (http.Request, error)
 }
 
 type requestFactory struct {
@@ -67,17 +67,17 @@ func configure(f *requestFactory, options []ClientOption) error {
 
 }
 
-func (f *hashRequestFactory) BuildRequest(entries []PayloadEntry, options ...ClientOption) (*http.Request, error) {
+func (f *hashRequestFactory) BuildRequest(entries []PayloadEntry, options ...ClientOption) (http.Request, error) {
 	return f.buildRequest(entries, getHashedPayloadBytes, options)
 }
 
-func (f *eventRequestFactory) BuildRequest(entries []PayloadEntry, options ...ClientOption) (*http.Request, error) {
+func (f *eventRequestFactory) BuildRequest(entries []PayloadEntry, options ...ClientOption) (http.Request, error) {
 	return f.buildRequest(entries, getEventPayloadBytes, options)
 }
 
 type payloadWriter func(buf *bytes.Buffer, entries []PayloadEntry)
 
-func (f *requestFactory) buildRequest(entries []PayloadEntry, getPayloadBytes payloadWriter, options []ClientOption) (*http.Request, error) {
+func (f *requestFactory) buildRequest(entries []PayloadEntry, getPayloadBytes payloadWriter, options []ClientOption) (http.Request, error) {
 	configuredFactory := f
 	if len(options) > 0 {
 		configuredFactory = &requestFactory{
@@ -93,7 +93,7 @@ func (f *requestFactory) buildRequest(entries []PayloadEntry, getPayloadBytes pa
 		err := configure(configuredFactory, options)
 
 		if err != nil {
-			return &http.Request{}, errors.New("unable to configure this request based on options passed in")
+			return http.Request{}, errors.New("unable to configure this request based on options passed in")
 		}
 	}
 
@@ -106,7 +106,7 @@ func (f *requestFactory) buildRequest(entries []PayloadEntry, getPayloadBytes pa
 	zipper.Reset(&compressedBuffer)
 	err := internal.CompressWithWriter(buf.Bytes(), zipper)
 	if err != nil {
-		return &http.Request{}, err
+		return http.Request{}, err
 	}
 	buf = &compressedBuffer
 
@@ -119,7 +119,7 @@ func (f *requestFactory) buildRequest(entries []PayloadEntry, getPayloadBytes pa
 	endpoint := configuredFactory.endpoint
 	headers := configuredFactory.getHeaders()
 
-	return &http.Request{
+	return http.Request{
 		Method: "POST",
 		URL: &url.URL{
 			Scheme: configuredFactory.scheme,

--- a/telemetry/request_test.go
+++ b/telemetry/request_test.go
@@ -5,11 +5,11 @@ package telemetry
 
 import (
 	"encoding/json"
+	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"testing"
-	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
 )
 
 type testUnsplittablePayloadEntry struct {
@@ -25,7 +25,7 @@ func (p *testUnsplittablePayloadEntry) Bytes() []byte {
 }
 
 type testSplittablePayloadEntry struct {
-	rawData json.RawMessage
+	rawData       json.RawMessage
 	splitPayloads []*testSplittablePayloadEntry
 }
 
@@ -38,7 +38,7 @@ func (p *testSplittablePayloadEntry) Bytes() []byte {
 }
 
 func (p *testSplittablePayloadEntry) split() []splittablePayloadEntry {
-	if (nil == p.splitPayloads) {
+	if nil == p.splitPayloads {
 		return nil
 	}
 
@@ -52,7 +52,7 @@ func (p *testSplittablePayloadEntry) split() []splittablePayloadEntry {
 func TestNewRequestNoSplitNeeded(t *testing.T) {
 	testPayload := testUnsplittablePayloadEntry{rawData: json.RawMessage(`123456789`)}
 	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal(entries, testFactory(), func(r *http.Request) bool {
+	reqs, err := newRequestsInternal(entries, testFactory(), func(r http.Request) bool {
 		return false
 	})
 	if err != nil {
@@ -72,10 +72,10 @@ func TestNewRequestSplitNeeded(t *testing.T) {
 		},
 	}
 	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal(entries, testFactory(), func(r *http.Request) bool {
+	reqs, err := newRequestsInternal(entries, testFactory(), func(r http.Request) bool {
 		shouldSplit, err := payloadContains(r, "testSplittable", "123456789")
 
-		if (nil != err) {
+		if nil != err {
 			t.Error(err)
 		}
 
@@ -101,10 +101,10 @@ func TestNewRequestSplittingMultiplePayloadsNeeded(t *testing.T) {
 		},
 	}
 	entries := []PayloadEntry{&testUnsplittablePayloadEntry, &testSplittablePayload}
-	reqs, err := newRequestsInternal(entries, testFactory(), func(r *http.Request) bool {
+	reqs, err := newRequestsInternal(entries, testFactory(), func(r http.Request) bool {
 		shouldSplit, err := payloadContains(r, "testSplittable", "123456789")
 
-		if (nil != err) {
+		if nil != err {
 			t.Error(err)
 		}
 
@@ -120,18 +120,18 @@ func TestNewRequestSplittingMultiplePayloadsNeeded(t *testing.T) {
 	expectedSplitPayloads := []string{"1234", "56789"}
 	for i := 0; i < 2; i++ {
 		hasUnsplittablePayload, err := payloadContains(reqs[i], "testUnsplittable", "abc")
-		if (err != nil) {
+		if err != nil {
 			t.Error(err)
 		}
-		if (!hasUnsplittablePayload) {
+		if !hasUnsplittablePayload {
 			t.Error("Each request should contain the unsplittable payload")
 		}
 
 		hasSplittablePayload, err := payloadContains(reqs[i], "testSplittable", expectedSplitPayloads[i])
-		if (err != nil) {
+		if err != nil {
 			t.Error(err)
 		}
-		if (!hasSplittablePayload) {
+		if !hasSplittablePayload {
 			t.Errorf("testSplittable did not contain %q", expectedSplitPayloads[i])
 		}
 	}
@@ -142,10 +142,10 @@ func TestNewRequestCantSplitPayload(t *testing.T) {
 		rawData: json.RawMessage(`"123456789"`),
 	}
 	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal(entries, testFactory(), func(r *http.Request) bool {
+	reqs, err := newRequestsInternal(entries, testFactory(), func(r http.Request) bool {
 		shouldSplit, err := payloadContains(r, "testSplittable", "123456789")
 
-		if (nil != err) {
+		if nil != err {
 			t.Error(err)
 		}
 
@@ -169,16 +169,16 @@ func TestNewRequestCantSplitPayloadsEnough(t *testing.T) {
 		},
 	}
 	entries := []PayloadEntry{&testPayload}
-	reqs, err := newRequestsInternal(entries, testFactory(), func(r *http.Request) bool {
+	reqs, err := newRequestsInternal(entries, testFactory(), func(r http.Request) bool {
 		isOriginalPayload, err := payloadContains(r, "testSplittable", "123456789")
 
-		if (nil != err) {
+		if nil != err {
 			t.Error(err)
 		}
 
 		isPayloadThatCantBeSplitAgain, err := payloadContains(r, "testSplittable", "56789")
 
-		if (nil != err) {
+		if nil != err {
 			t.Error(err)
 		}
 
@@ -221,7 +221,7 @@ func TestLargeRequestNoSplit(t *testing.T) {
 	}
 }
 
-func payloadContains(r *http.Request, fieldName string, value string) (bool, error) {
+func payloadContains(r http.Request, fieldName string, value string) (bool, error) {
 	bodyReader, _ := r.GetBody()
 	compressedBytes, _ := ioutil.ReadAll(bodyReader)
 	uncompressedBytes, _ := internal.Uncompress(compressedBytes)
@@ -240,7 +240,7 @@ func randomJSON(numBytes int) json.RawMessage {
 	return js
 }
 
-func testFactory() (RequestFactory) {
+func testFactory() RequestFactory {
 	factory, _ := NewMetricRequestFactory(WithNoDefaultKey())
 	return factory
 }


### PR DESCRIPTION
This is an experiment to use the stack for passing requests. This makes it easier to optimize for gc / heap allocations.