### PR TITLE
Add telemetry SDK edits for 0.7.0 release.

### DIFF
--- a/telemetry/attributes_test.go
+++ b/telemetry/attributes_test.go
@@ -1,0 +1,47 @@
+package telemetry
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_newCommonAttributes(t *testing.T) {
+	type args struct {
+		attributes map[string]interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *commonAttributes
+		wantErr bool
+	}{
+		{
+			name: "Nil Attributes",
+			args: args{
+				attributes: nil,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "Length 0 Attributes",
+			args: args{
+				attributes: map[string]interface{}{},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newCommonAttributes(tt.args.attributes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newCommonAttributes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newCommonAttributes() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/telemetry/events_group_test.go
+++ b/telemetry/events_group_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
 )
 
-func testEventBatchJSON(t testing.TB, batches []Batch, expect string) {
+func testEventGroupJSON(t testing.TB, batches []Batch, expect string) {
 	if th, ok := t.(interface{ Helper() }); ok {
 		th.Helper()
 	}
@@ -48,43 +48,43 @@ func TestEventsPayloadSplit(t *testing.T) {
 	t.Parallel()
 
 	// test len 0
-	ev := &eventBatch{}
+	ev := &eventGroup{}
 	split := ev.split()
 	if split != nil {
 		t.Error(split)
 	}
 
 	// test len 1
-	ev = &eventBatch{Events: []Event{{EventType: "a"}}}
+	ev = &eventGroup{Events: []Event{{EventType: "a"}}}
 	split = ev.split()
 	if split != nil {
 		t.Error(split)
 	}
 
 	// test len 2
-	ev = &eventBatch{Events: []Event{{EventType: "a"}, {EventType: "b"}}}
+	ev = &eventGroup{Events: []Event{{EventType: "a"}, {EventType: "b"}}}
 	split = ev.split()
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
 
-	testEventBatchJSON(t, []Batch{{split[0]}}, `[{"eventType":"a","timestamp":-6795364578871}]`)
-	testEventBatchJSON(t, []Batch{{split[1]}}, `[{"eventType":"b","timestamp":-6795364578871}]`)
+	testEventGroupJSON(t, []Batch{{split[0]}}, `[{"eventType":"a","timestamp":-6795364578871}]`)
+	testEventGroupJSON(t, []Batch{{split[1]}}, `[{"eventType":"b","timestamp":-6795364578871}]`)
 
 	// test len 3
-	ev = &eventBatch{Events: []Event{{EventType: "a"}, {EventType: "b"}, {EventType: "c"}}}
+	ev = &eventGroup{Events: []Event{{EventType: "a"}, {EventType: "b"}, {EventType: "c"}}}
 	split = ev.split()
 	if len(split) != 2 {
 		t.Error("split into incorrect number of slices", len(split))
 	}
-	testEventBatchJSON(t, []Batch{{split[0]}}, `[{"eventType":"a","timestamp":-6795364578871}]`)
-	testEventBatchJSON(t, []Batch{{split[1]}}, `[{"eventType":"b","timestamp":-6795364578871},{"eventType":"c","timestamp":-6795364578871}]`)
+	testEventGroupJSON(t, []Batch{{split[0]}}, `[{"eventType":"a","timestamp":-6795364578871}]`)
+	testEventGroupJSON(t, []Batch{{split[1]}}, `[{"eventType":"b","timestamp":-6795364578871},{"eventType":"c","timestamp":-6795364578871}]`)
 }
 
 func TestEventsJSON(t *testing.T) {
 	t.Parallel()
 
-	batch1 := &eventBatch{Events: []Event{
+	group1 := &eventGroup{Events: []Event{
 		{}, // Empty
 		{ // with everything
 			EventType:  "testEvent",
@@ -92,10 +92,10 @@ func TestEventsJSON(t *testing.T) {
 			Attributes: map[string]interface{}{"zip": "zap"},
 		},
 	}}
-	batch2 := &eventBatch{Events: []Event{{EventType: "a"}}}
-	batch3 := &eventBatch{Events: []Event{{EventType: "b"}}}
+	group2 := &eventGroup{Events: []Event{{EventType: "a"}}}
+	group3 := &eventGroup{Events: []Event{{EventType: "b"}}}
 
-	testEventBatchJSON(t, []Batch{{batch1, batch2}, {batch3}}, `[
+	testEventGroupJSON(t, []Batch{{group1, group2}, {group3}}, `[
 		{
 		  "eventType":"",
 		  "timestamp":-6795364578871
@@ -116,7 +116,7 @@ func TestEventsJSON(t *testing.T) {
 	]`)
 }
 
-func TestEventBatchSplittable(t *testing.T) {
-	batch := &eventBatch{Events: []Event{{EventType: "a"}}}
-	_ = splittablePayloadEntry(batch)
+func TestEventGroupSplittable(t *testing.T) {
+	group := &eventGroup{Events: []Event{{EventType: "a"}}}
+	_ = splittablePayloadEntry(group)
 }

--- a/telemetry/logs_test.go
+++ b/telemetry/logs_test.go
@@ -4,6 +4,7 @@
 package telemetry
 
 import (
+	"bytes"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -13,12 +14,12 @@ import (
 
 func BenchmarkLogsJSON(b *testing.B) {
 	// This benchmark tests the overhead of turning logs into JSON.
-	batch := &LogBatch{}
+	group := &logGroup{}
 	numLogs := 10 * 1000
 	tm := time.Date(2014, time.November, 28, 1, 1, 0, 0, time.UTC)
 
 	for i := 0; i < numLogs; i++ {
-		batch.Logs = append(batch.Logs, Log{
+		group.Logs = append(group.Logs, Log{
 			Message:   "This is a log message.",
 			Timestamp: tm,
 		})
@@ -27,9 +28,11 @@ func BenchmarkLogsJSON(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
+	buf := &bytes.Buffer{}
 	for i := 0; i < b.N; i++ {
-		if bts := batch.Bytes(); nil == bts || len(bts) == 0 {
-			b.Fatal(string(bts))
+		buf.Reset()
+		if group.WriteDataEntry(buf); nil == buf.Bytes() || len(buf.Bytes()) == 0 {
+			b.Fatal(string(buf.Bytes()))
 		}
 	}
 }

--- a/telemetry/request_factory_test.go
+++ b/telemetry/request_factory_test.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"bytes"
 	"compress/gzip"
 	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
 	"io/ioutil"
@@ -61,12 +62,14 @@ func TestClientOptions(t *testing.T) {
 
 type MockPayloadEntry struct{}
 
-func (m *MockPayloadEntry) Type() string {
+func (m *MockPayloadEntry) DataTypeKey() string {
 	return "spans"
 }
 
-func (m *MockPayloadEntry) Bytes() []byte {
-	return []byte{'[', ']'}
+func (m *MockPayloadEntry) WriteDataEntry(buf *bytes.Buffer) *bytes.Buffer {
+	buf.WriteByte('[')
+	buf.WriteByte(']')
+	return buf
 }
 
 func TestSpanFactoryRequest(t *testing.T) {


### PR DESCRIPTION
This PR contains a number of improvements to the telemetry SDK

## Breaking Changes ⚠️ 
* BuildRequest on Request factories now have new interfaces to reflect the outline of the payload. Helpers for common blocks and groups are provided.

## Performance Improvements 🚀 
* Buffer allocations are now minimized within the request factory via internal buffer caching and re-use.