### PR TITLE
Add New Relic Community Project header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
+
 # Go Telemetry SDK [![GoDoc](https://godoc.org/github.com/newrelic/newrelic-telemetry-sdk-go?status.svg)](https://godoc.org/github.com/newrelic/newrelic-telemetry-sdk-go)
 
 What is the New Relic Go Telemetry SDK?

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
+[![Community Project header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Project.png)](https://opensource.newrelic.com/oss-category/#community-project)
 
 # Go Telemetry SDK [![GoDoc](https://godoc.org/github.com/newrelic/newrelic-telemetry-sdk-go?status.svg)](https://godoc.org/github.com/newrelic/newrelic-telemetry-sdk-go)
 


### PR DESCRIPTION
According to [this internal New Relic spreadsheet](https://docs.google.com/spreadsheets/d/1yT_JfIPnReYmEk8PXoc8oNd4DX8NpeyVE_XEIxyxmnE/edit?usp=sharing), this project is supported as a Community Plus repo.