### PR TITLE
sanitize API key for logging on harvester creation

### DIFF
--- a/telemetry/harvester.go
+++ b/telemetry/harvester.go
@@ -11,6 +11,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -42,6 +43,9 @@ const (
 	// NOTE:  These constant values are used in Config field doc comments.
 	defaultHarvestPeriod  = 5 * time.Second
 	defaultHarvestTimeout = 15 * time.Second
+
+	// euKeyPrefix is used to sanitize the api-key for logging.
+	euKeyPrefix = "eu01xx"
 )
 
 var (
@@ -132,7 +136,7 @@ func NewHarvester(options ...func(*Config)) (*Harvester, error) {
 
 	h.config.logDebug(map[string]interface{}{
 		"event":                  "harvester created",
-		"api-key":                h.config.APIKey,
+		"api-key":                sanitizeAPIKeyForLogging(h.config.APIKey),
 		"harvest-period-seconds": h.config.HarvestPeriod.Seconds(),
 		"metrics-url-override":   h.config.MetricsURLOverride,
 		"spans-url-override":     h.config.SpansURLOverride,
@@ -146,6 +150,17 @@ func NewHarvester(options ...func(*Config)) (*Harvester, error) {
 	}
 
 	return h, nil
+}
+
+func sanitizeAPIKeyForLogging(apiKey string) string {
+	if len(apiKey) <= 8 {
+		return apiKey
+	}
+	end := 8
+	if strings.HasPrefix(apiKey, euKeyPrefix) {
+		end += len(euKeyPrefix)
+	}
+	return apiKey[:end]
 }
 
 var (

--- a/telemetry/harvester_test.go
+++ b/telemetry/harvester_test.go
@@ -129,6 +129,19 @@ func validateReqUsedCorrectEndpointValues(reqs []*http.Request, expectedURL stri
 	}
 }
 
+func TestSanitizeApiKeyForLogging(t *testing.T) {
+	assertEqual := func(expected, actual string) {
+		if actual != expected {
+			t.Errorf("Got %s but expected %s", actual, expected)
+		}
+	}
+	assertEqual("", sanitizeAPIKeyForLogging(""))
+	assertEqual("", sanitizeAPIKeyForLogging(""))
+	assertEqual("foo", sanitizeAPIKeyForLogging("foo"))
+	assertEqual("foobarba", sanitizeAPIKeyForLogging("foobarbazqux"))
+	assertEqual("eu01xxfoobarba", sanitizeAPIKeyForLogging("eu01xxfoobarbazqux"))
+}
+
 func TestHarvesterRecordSpan(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
It's probably not a good idea to log api keys. I noticed the new relic exporter for the open telemetry collector uses sanitation logic, so I copied that logic here.

related pr: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3690/files