### PR TITLE
Require a request context in the request factory.

### DIFF
--- a/telemetry/request.go
+++ b/telemetry/request.go
@@ -4,6 +4,7 @@
 package telemetry
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -31,7 +32,8 @@ func BuildSplitRequests(batches []Batch, factory RequestFactory) ([]*http.Reques
 }
 
 func newRequestsInternal(batches []Batch, factory RequestFactory, needsSplit func(*http.Request) bool) ([]*http.Request, error) {
-	r, err := factory.BuildRequest(batches)
+	// Context will be defined in the harvester when the request is actually submitted to the client
+	r, err := factory.BuildRequest(context.TODO(), batches)
 	if nil != err {
 		return nil, err
 	}

--- a/telemetry/request_factory_test.go
+++ b/telemetry/request_factory_test.go
@@ -3,9 +3,11 @@ package telemetry
 import (
 	"bytes"
 	"compress/gzip"
-	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
+	"context"
 	"io/ioutil"
 	"testing"
+
+	"github.com/newrelic/newrelic-telemetry-sdk-go/internal"
 )
 
 func TestNewRequestFactoryNoInsertKeyConfigSuccess(t *testing.T) {
@@ -74,7 +76,7 @@ func (m *MockPayloadEntry) WriteDataEntry(buf *bytes.Buffer) *bytes.Buffer {
 
 func TestSpanFactoryRequest(t *testing.T) {
 	f, _ := NewSpanRequestFactory(WithInsertKey("key!"))
-	request, _ := f.BuildRequest([]Batch{{&MockPayloadEntry{}}})
+	request, _ := f.BuildRequest(context.Background(), []Batch{{&MockPayloadEntry{}}})
 	if request.Method != "POST" {
 		t.Error("Method was not POST")
 	}


### PR DESCRIPTION
# Breaking Change 🚨 

This PR *requires* that request context be added when building a request. Using request context will allow requests to be cancelled properly when a context cancels.

My understanding is that it's generally considered best practice to use context when creating a request object.