### PR TITLE
Harvester improvements.

### DIFF
--- a/telemetry/events_group_test.go
+++ b/telemetry/events_group_test.go
@@ -16,7 +16,7 @@ func testEventGroupJSON(t testing.TB, batches []Batch, expect string) {
 		th.Helper()
 	}
 	factory, _ := NewEventRequestFactory(WithNoDefaultKey())
-	reqs, err := BuildSplitRequests(batches, factory)
+	reqs, err := buildSplitRequests(batches, factory)
 	if nil != err {
 		t.Fatal(err)
 	}

--- a/telemetry/harvester_test.go
+++ b/telemetry/harvester_test.go
@@ -261,7 +261,7 @@ func TestNewRequestHeaders(t *testing.T) {
 		cfg.Product = "myProduct"
 		cfg.ProductVersion = "0.1.0"
 	})
-	expectUserAgent := "NewRelic-Go-TelemetrySDK/" + version + " myProduct/0.1.0"
+	expectUserAgent := "NewRelic-Go-TelemetrySDK/" + version + " harvester myProduct/0.1.0"
 	h.RecordSpan(Span{TraceID: "id", ID: "id"})
 	h.RecordMetric(Gauge{})
 

--- a/telemetry/logs_group_test.go
+++ b/telemetry/logs_group_test.go
@@ -16,7 +16,7 @@ func testLogGroupJSON(t testing.TB, batches []Batch, expect string) {
 		th.Helper()
 	}
 	factory, _ := NewLogRequestFactory(WithNoDefaultKey())
-	reqs, err := BuildSplitRequests(batches, factory)
+	reqs, err := buildSplitRequests(batches, factory)
 	if nil != err {
 		t.Fatal(err)
 	}

--- a/telemetry/metrics_group_test.go
+++ b/telemetry/metrics_group_test.go
@@ -81,7 +81,7 @@ func TestMetrics(t *testing.T) {
 	}]`)
 
 	factory, _ := NewMetricRequestFactory(WithNoDefaultKey())
-	reqs, err := BuildSplitRequests([]Batch{{commonBlock, NewMetricGroup(metrics)}}, factory)
+	reqs, err := buildSplitRequests([]Batch{{commonBlock, NewMetricGroup(metrics)}}, factory)
 	if err != nil {
 		t.Error("error creating request", err)
 	}
@@ -117,7 +117,7 @@ func testGroupJSON(t testing.TB, batches []Batch, expect string) {
 		th.Helper()
 	}
 	factory, _ := NewMetricRequestFactory(WithNoDefaultKey())
-	reqs, err := BuildSplitRequests(batches, factory)
+	reqs, err := buildSplitRequests(batches, factory)
 	if nil != err {
 		t.Fatal(err)
 	}

--- a/telemetry/request.go
+++ b/telemetry/request.go
@@ -26,8 +26,8 @@ func requestNeedsSplit(r *http.Request) bool {
 	return r.ContentLength >= maxCompressedSizeBytes
 }
 
-// BuildSplitRequests converts a []Batch into a collection of appropiately sized requests
-func BuildSplitRequests(batches []Batch, factory RequestFactory) ([]*http.Request, error) {
+// buildSplitRequests converts a []Batch into a collection of appropiately sized requests
+func buildSplitRequests(batches []Batch, factory RequestFactory) ([]*http.Request, error) {
 	return newRequestsInternal(batches, factory, requestNeedsSplit)
 }
 

--- a/telemetry/request_test.go
+++ b/telemetry/request_test.go
@@ -214,7 +214,7 @@ func TestNeedsToSplitBatchesAndEntries(t *testing.T) {
 			rawData: randomJSON(maxCompressedSizeBytes),
 		},
 	}
-	reqs, err := BuildSplitRequests([]Batch{group1, group2}, testFactory())
+	reqs, err := buildSplitRequests([]Batch{group1, group2}, testFactory())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,7 +226,7 @@ func TestNeedsToSplitBatchesAndEntries(t *testing.T) {
 func TestLargeRequestNeedsSplit(t *testing.T) {
 	js := randomJSON(4 * maxCompressedSizeBytes)
 	payloadEntry := testUnsplittablePayloadEntry{rawData: js}
-	reqs, err := BuildSplitRequests([]Batch{{&payloadEntry}}, testFactory())
+	reqs, err := buildSplitRequests([]Batch{{&payloadEntry}}, testFactory())
 	if reqs != nil {
 		t.Error(reqs)
 	}
@@ -238,7 +238,7 @@ func TestLargeRequestNeedsSplit(t *testing.T) {
 func TestLargeRequestNoSplit(t *testing.T) {
 	js := randomJSON(maxCompressedSizeBytes / 2)
 	payloadEntry := testUnsplittablePayloadEntry{rawData: js}
-	reqs, err := BuildSplitRequests([]Batch{{&payloadEntry}}, testFactory())
+	reqs, err := buildSplitRequests([]Batch{{&payloadEntry}}, testFactory())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/telemetry/spans_group_test.go
+++ b/telemetry/spans_group_test.go
@@ -16,7 +16,7 @@ func testSpanGroupJSON(t testing.TB, batches []Batch, expect string) {
 		th.Helper()
 	}
 	factory, _ := NewSpanRequestFactory(WithNoDefaultKey())
-	reqs, err := BuildSplitRequests(batches, factory)
+	reqs, err := buildSplitRequests(batches, factory)
 	if nil != err {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR does the following:
* Adds a `harvester` tag to the user agent to measure use of the harvester struct
* Uses a sync.WaitGroup to manage concurrent requests for each data type. This means that data will arrive quickly and context timeouts will be less likely.
* Makes buildSplitRequests package internal